### PR TITLE
buy.u.c clean up

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,20 +1,17 @@
 .p-button--shop-cta {
   width: 100%; }
-
-@media (min-width: 772px) {
-  .p-button--shop-cta {
-    padding: 1rem; } }
-
-.p-button--shop-cta + .p-button--shop-cta {
-  margin-top: 1rem; }
+  @media (min-width: 772px) {
+    .p-button--shop-cta {
+      padding: 1rem; } }
+  .p-button--shop-cta + .p-button--shop-cta {
+    margin-top: 1rem; }
 
 .p-button__postscript {
   display: block;
   margin-bottom: .5rem; }
-
-@media (min-width: 772px) {
-  .p-button__postscript {
-    min-height: 2rem; } }
+  @media (min-width: 772px) {
+    .p-button__postscript {
+      min-height: 2rem; } }
 
 .p-inline-grid {
   border: 1px solid #cdcdcd;
@@ -23,33 +20,27 @@
   list-style-type: none;
   margin: 0;
   padding: 0; }
-
-.p-inline-grid__cta {
-  cursor: pointer;
-  transition-duration: 0.165s;
-  transition-property: background-color;
-  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
-
-.p-inline-grid__cta:hover {
-  background-color: #cdcdcd; }
-
-.p-inline-grid li {
-  border-right: 1px solid #cdcdcd;
-  flex: 1 1 100%; }
-
-.p-inline-grid li:last-child {
-  border-right: none; }
-
-.p-inline-grid li > * {
-  height: 100%;
-  width: 100%; }
-
-.p-inline-grid input[readonly] {
-  border: 0;
-  color: #333;
-  margin: 0;
-  min-width: 0;
-  text-align: inherit; }
+  .p-inline-grid__cta {
+    cursor: pointer;
+    transition-duration: 0.165s;
+    transition-property: background-color;
+    transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
+    .p-inline-grid__cta:hover {
+      background-color: #cdcdcd; }
+  .p-inline-grid li {
+    border-right: 1px solid #cdcdcd;
+    flex: 1 1 100%; }
+    .p-inline-grid li:last-child {
+      border-right: none; }
+    .p-inline-grid li > * {
+      height: 100%;
+      width: 100%; }
+  .p-inline-grid input[readonly] {
+    border: 0;
+    color: #333;
+    margin: 0;
+    min-width: 0;
+    text-align: inherit; }
 
 @media (min-width: 772px) {
   .p-list__item--tall {
@@ -57,63 +48,53 @@
 
 .p-navigation {
   background-color: #333; }
-
-.p-navigation::after {
-  background: transparent; }
-
-.p-navigation .p-navigation__logo > a, .p-navigation .p-navigation__logo > a:visited, .p-navigation .p-navigation__logo > a:focus,
-.p-navigation .p-navigation__link > a,
-.p-navigation .p-navigation__link > a:visited,
-.p-navigation .p-navigation__link > a:focus,
-.p-navigation .p-navigation__toggle--close,
-.p-navigation .p-navigation__toggle--close:visited,
-.p-navigation .p-navigation__toggle--close:focus,
-.p-navigation .p-navigation__toggle--open,
-.p-navigation .p-navigation__toggle--open:visited,
-.p-navigation .p-navigation__toggle--open:focus {
-  color: white; }
-
-.p-navigation .p-navigation__link > a,
-.p-navigation .p-navigation__toggle--close,
-.p-navigation .p-navigation__toggle--open {
-  padding-top: 0.95rem; }
-
-.p-navigation .p-navigation__logo span {
-  align-self: flex-end;
-  margin-left: 0.5rem;
-  padding-bottom: 0.15rem; }
-
-.p-navigation .p-navigation__link > a::before {
-  background: transparent; }
-
-.p-navigation .p-navigation__link > a:hover {
-  background: #2b2b2b; }
-
-.p-navigation__link--cart {
-  order: 1;
-  padding: 0.5rem 1.5rem 0;
-  position: relative; }
-
-@media (max-width: 771px) {
+  .p-navigation::after {
+    background: transparent; }
+  .p-navigation .p-navigation__logo > a, .p-navigation .p-navigation__logo > a:visited, .p-navigation .p-navigation__logo > a:focus,
+  .p-navigation .p-navigation__link > a,
+  .p-navigation .p-navigation__link > a:visited,
+  .p-navigation .p-navigation__link > a:focus,
+  .p-navigation .p-navigation__toggle--close,
+  .p-navigation .p-navigation__toggle--close:visited,
+  .p-navigation .p-navigation__toggle--close:focus,
+  .p-navigation .p-navigation__toggle--open,
+  .p-navigation .p-navigation__toggle--open:visited,
+  .p-navigation .p-navigation__toggle--open:focus {
+    color: white; }
+  .p-navigation .p-navigation__link > a,
+  .p-navigation .p-navigation__toggle--close,
+  .p-navigation .p-navigation__toggle--open {
+    padding-top: 0.95rem; }
+  .p-navigation .p-navigation__logo span {
+    align-self: flex-end;
+    margin-left: 0.5rem;
+    padding-bottom: 0.15rem; }
+  .p-navigation .p-navigation__link > a::before {
+    background: transparent; }
+  .p-navigation .p-navigation__link > a:hover {
+    background: #2b2b2b; }
   .p-navigation__link--cart {
-    padding: .75rem 1.5rem; } }
-
-.p-navigation__link--cart:hover {
-  background: #2b2b2b; }
-
-.p-navigation__link--cart-count::before {
-  background-color: #c7162b;
-  border-radius: 100%;
-  color: #fff;
-  content: attr(data-item-count);
-  display: block;
-  height: 1.5rem;
-  font-weight: bold;
-  position: absolute;
-  right: .7rem;
-  text-align: center;
-  top: .2rem;
-  width: 1.5rem; }
+    order: 1;
+    padding: 0.5rem 1.5rem 0;
+    position: relative; }
+    @media (max-width: 771px) {
+      .p-navigation__link--cart {
+        padding: .75rem 1.5rem; } }
+    .p-navigation__link--cart:hover {
+      background: #2b2b2b; }
+    .p-navigation__link--cart-count::before {
+      background-color: #c7162b;
+      border-radius: 100%;
+      color: #fff;
+      content: attr(data-item-count);
+      display: block;
+      height: 1.5rem;
+      font-weight: bold;
+      position: absolute;
+      right: .7rem;
+      text-align: center;
+      top: .2rem;
+      width: 1.5rem; }
 
 @media (min-width: 772px) {
   .p-product-description {

--- a/src/config/settings_data.json
+++ b/src/config/settings_data.json
@@ -72,7 +72,7 @@
     "tac_copy": "I confirm acceptance to the terms of the <a href=\"http://www.ubuntu.com/legal/short-terms\" target=\"_blank\">services agreement</a> for and on behalf of the company identified in the order.",
     "footer_nav_headline": "More on Commercial Support",
     "footer_help_headline": "Community Support",
-    "footer_help_content": "You can get help from the <a href=\"https://ubuntu.com/support/community-support\"target=\"_blank\">community</a>, join a <a href=\"http://ubuntuforums.org/\"target=\"_blank\">forum</a>, or take a look at our <a href=\"https://help.ubuntu.com/?_ga=1.231772636.2119600767.1461864987\"target=\"_blank\">official documentation</a>.\n\n<a href=\"https://ubuntu.com/support/community-support\">Learn about community support  ›</a><br /><br />",
+    "footer_help_content": "You can get help from the <a href=\"https://ubuntu.com/support/community-support\" target=\"_blank\">community</a>, join a <a href=\"http://ubuntuforums.org/\" target=\"_blank\">forum</a>, or take a look at our <a href=\"https://help.ubuntu.com/?_ga=1.231772636.2119600767.1461864987\" target=\"_blank\">official documentation</a>.\n\n<a href=\"https://ubuntu.com/support/community-support\">Learn about community support  ›</a><br /><br />",
     "footer_help_button_display": false,
     "footer_help_button_text": "Contact Us",
     "footer_help_button_link": "http://www.ubuntu.com/about/contact-us/form",

--- a/src/layout/theme.liquid
+++ b/src/layout/theme.liquid
@@ -4,7 +4,7 @@
 <!--[if IE 7]><html class="no-js lt-ie9 lt-ie8" lang="en"> <![endif]-->
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en"> <![endif]-->
 <!--[if IE 9 ]><html class="ie9 no-js"> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--> <html class="no-js"> <!--<![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
   <head>
     <meta charset="utf-8" />
     <!--[if IE]><meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1' /><![endif]-->

--- a/src/layout/theme.liquid
+++ b/src/layout/theme.liquid
@@ -5,76 +5,76 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en"> <![endif]-->
 <!--[if IE 9 ]><html class="ie9 no-js"> <![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!--> <html class="no-js"> <!--<![endif]-->
-<head>
-  <meta charset="utf-8" />
-  <!--[if IE]><meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1' /><![endif]-->
+  <head>
+    <meta charset="utf-8" />
+    <!--[if IE]><meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1' /><![endif]-->
 
-  <title>
-  {{ page_title }}{% if current_tags %} &ndash; tagged "{{ current_tags | join: ', ' }}"{% endif %}{% if current_page != 1 %} &ndash; Page {{ current_page }}{% endif %}{% unless page_title contains shop.name %} &ndash; {{ shop.name }}{% endunless %}
-  </title>
+    <title>
+    {{ page_title }}{% if current_tags %} &ndash; tagged "{{ current_tags | join: ', ' }}"{% endif %}{% if current_page != 1 %} &ndash; Page {{ current_page }}{% endif %}{% unless page_title contains shop.name %} &ndash; {{ shop.name }}{% endunless %}
+    </title>
 
-  {% if page_description %}
-  <meta name="description" content="{{ page_description | escape }}" />
-  {% endif %}
+    {% if page_description %}
+    <meta name="description" content="{{ page_description | escape }}" />
+    {% endif %}
 
-  <link rel="canonical" href="{{ canonical_url }}" />
+    <link rel="canonical" href="{{ canonical_url }}" />
 
-  <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16" />
-  <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32" />
 
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://assets.ubuntu.com/v1/3361409d-apple-touch-icon-144x144-precomposed.png" />
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://assets.ubuntu.com/v1/5fe4d3c8-apple-touch-icon-114x114-precomposed.png" />
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://assets.ubuntu.com/v1/09460d9a-apple-touch-icon-72x72-precomposed.png" />
-  <link rel="apple-touch-icon-precomposed" href="https://assets.ubuntu.com/v1/cc66da65-apple-touch-icon-precomposed.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://assets.ubuntu.com/v1/3361409d-apple-touch-icon-144x144-precomposed.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://assets.ubuntu.com/v1/5fe4d3c8-apple-touch-icon-114x114-precomposed.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://assets.ubuntu.com/v1/09460d9a-apple-touch-icon-72x72-precomposed.png" />
+    <link rel="apple-touch-icon-precomposed" href="https://assets.ubuntu.com/v1/cc66da65-apple-touch-icon-precomposed.png" />
 
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  {% include 'open-graph-tags' %}
-  {% include 'twitter-card' %}
+    {% include 'open-graph-tags' %}
+    {% include 'twitter-card' %}
 
-  {{ content_for_header }}
+    {{ content_for_header }}
 
-  {{ '//fonts.googleapis.com/css?family=Ubuntu:400,300' | stylesheet_tag }}
+    {{ '//fonts.googleapis.com/css?family=Ubuntu:400,300' | stylesheet_tag }}
 
-  <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-2.3.0.min.css" />
+    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-2.3.0.min.css" />
 
-  {{ 'style.css' | asset_url | stylesheet_tag }}
+    {{ 'style.css' | asset_url | stylesheet_tag }}
 
-  <!--[if lt IE 9]>
-  {{ '//html5shiv.googlecode.com/svn/trunk/html5.js' | script_tag }}
-  <![endif]-->
+    <!--[if lt IE 9]>
+    {{ '//html5shiv.googlecode.com/svn/trunk/html5.js' | script_tag }}
+    <![endif]-->
 
-  {{ 'shopify_common.js' | shopify_asset_url | script_tag }}
-  {% if template contains 'customers' %}
-  {{ 'customer_area.js'  | shopify_asset_url | script_tag }}
-  {% endif %}
+    {{ 'shopify_common.js' | shopify_asset_url | script_tag }}
+    {% if template contains 'customers' %}
+    {{ 'customer_area.js'  | shopify_asset_url | script_tag }}
+    {% endif %}
 
-  <!-- Additional Shopify helpers that will likely be added to the global shopify_common.js some day soon. -->
-  {{ 'shopify_common.js'  | asset_url | script_tag }}
+    <!-- Additional Shopify helpers that will likely be added to the global shopify_common.js some day soon. -->
+    {{ 'shopify_common.js'  | asset_url | script_tag }}
 
-  {{ 'option_selection.js' | shopify_asset_url | script_tag }}
+    {{ 'option_selection.js' | shopify_asset_url | script_tag }}
 
-  {{ '//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js' | script_tag }}
-  <script>jQuery('html').removeClass('no-js').addClass('js');</script>
-
-
-{% include "livechat_monitoring_code" %}
-</head>
-
-<body id="{{ page_title | handle }}" class="{% if customer %}customer-logged-in {% endif %}template-{{ template | replace: '.', ' ' | truncatewords: 1, '' | handle }}" >
-
-  {{ content_for_layout }}
-
-  {% include 'footer' %}
-
-  {% comment %}Shopify does not support Internet Explorer 6 nor 7. It does encourage themes to support IE8 until the end of 2014.{% endcomment %}
-  <!--[if lt IE 8]>
-  <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
-  <![endif]-->
+    {{ '//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js' | script_tag }}
+    <script>jQuery('html').removeClass('no-js').addClass('js');</script>
 
 
-  <!-- {{ 'shop.js' | asset_url | script_tag }} -->
+  {% include "livechat_monitoring_code" %}
+  </head>
 
-  {{ 'canonical.min.js'  | asset_url | script_tag }}
-</body>
+  <body id="{{ page_title | handle }}" class="{% if customer %}customer-logged-in {% endif %}template-{{ template | replace: '.', ' ' | truncatewords: 1, '' | handle }}" >
+
+    {{ content_for_layout }}
+
+    {% include 'footer' %}
+
+    {% comment %}Shopify does not support Internet Explorer 6 nor 7. It does encourage themes to support IE8 until the end of 2014.{% endcomment %}
+    <!--[if lt IE 8]>
+    <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
+    <![endif]-->
+
+
+    <!-- {{ 'shop.js' | asset_url | script_tag }} -->
+
+    {{ 'canonical.min.js'  | asset_url | script_tag }}
+  </body>
 </html>

--- a/src/layout/theme.liquid
+++ b/src/layout/theme.liquid
@@ -62,8 +62,11 @@
   </head>
 
   <body id="{{ page_title | handle }}" class="{% if customer %}customer-logged-in {% endif %}template-{{ template | replace: '.', ' ' | truncatewords: 1, '' | handle }}" >
-
-    {{ content_for_layout }}
+    {% include 'site-nav' %}
+    
+    <div id="main-content" class="main" role="main">
+      {{ content_for_layout }}
+    </div>
 
     {% include 'footer' %}
 

--- a/src/snippets/footer.liquid
+++ b/src/snippets/footer.liquid
@@ -4,7 +4,7 @@
       {% if linklists.footer.links.size > 0 %}
       <div class="col-3">
         <h4 class="p-muted-heading">{{ settings.footer_nav_headline | upcase }}</h4>
-        <ul class="p-list" role="navigation">
+        <ul class="p-list">
         {% for link in linklists.footer.links %}
           <li class="p-list__item"><a href="{{ link.url }}" title="{{ link.title }}"{% if link.active %} class="active"{% endif %}>{{ link.title }}</a></li>
         {% endfor %}

--- a/src/snippets/header.liquid
+++ b/src/snippets/header.liquid
@@ -3,7 +3,7 @@
     <div class="p-strip is-deep" style="background-image: url({{ 'homepage_hero-graph.png' | asset_url }});">
       <div class="u-fixed-width">
         <h1>{{ settings.homepage_main_heading }}</h1>
-        <h2 class="p-heading--four">{{ settings.homepage_sub_heading }}</h4>
+        <h2 class="p-heading--four">{{ settings.homepage_sub_heading }}</h2>
         <a class="p-button--positive" href="/collections/ubuntu-advantage-for-infrastructure-essential">Get started with our Essential plan from $25</a>
         <p><a class="p-link--inverted p-link--external" href="https://ubuntu.com/support" title="Get UA Infrastructure Essential" target="blank">Learn more about our support options</a></p>
       </div>

--- a/src/snippets/site-nav.liquid
+++ b/src/snippets/site-nav.liquid
@@ -3,7 +3,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo" style="padding-bottom: 0.3rem;">
         <a class="p-navigation__link" href="/">
-          <img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" class="p-navigation__image" style="max-height: 1.5rem;" />
+          <img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" class="p-navigation__image" style="max-height: 1.5rem;" alt="Ubuntu logo" />
           <span class="p-heading--five u-no-margin--bottom">advantage</span>
         </a>
       </div>
@@ -19,7 +19,7 @@
       </span>
       <ul class="p-navigation__links" role="menu">
         {% for link in linklists.main-menu.links %}
-          <li class="p-navigation__link" role="menu-item">
+          <li class="p-navigation__link" role="menuitem">
             <a href="{{ link.url }}">{{ link.title }}</a>
           </li>
         {% endfor %}

--- a/src/templates/404.liquid
+++ b/src/templates/404.liquid
@@ -1,2 +1,12 @@
-<h1 class="centered">404 Page Not Found</h1>
-<h2 class="delta centered">The page you requested does not exist. Click <a href="/collections/all">here</a> to continue shopping.</h2>
+{% include 'site-nav' %}
+
+<div id="main-content" class="main" role="main">
+  <section class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-12">
+        <h1>404 Page Not Found</h1>
+        <h2>The page you requested does not exist. Click <a href="/collections/all">here</a> to continue shopping.</h2>
+      </div>
+    </div>
+  </section>
+</div>

--- a/src/templates/404.liquid
+++ b/src/templates/404.liquid
@@ -1,12 +1,8 @@
-{% include 'site-nav' %}
-
-<div id="main-content" class="main" role="main">
-  <section class="p-strip is-bordered">
-    <div class="row">
-      <div class="col-12">
-        <h1>404 Page Not Found</h1>
-        <h2>The page you requested does not exist. Click <a href="/collections/all">here</a> to continue shopping.</h2>
-      </div>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h1>404 Page Not Found</h1>
+      <h2>The page you requested does not exist. Click <a href="/collections/all">here</a> to continue shopping.</h2>
     </div>
-  </section>
-</div>
+  </div>
+</section>

--- a/src/templates/article.liquid
+++ b/src/templates/article.liquid
@@ -3,59 +3,55 @@
 	window.location.replace("{{ shop.url }}");
 </script>
 
-{% include 'site-nav' %}
-
-<div id="main-content" class="main" role="main">
-  <article>
-    <div class="p-strip--light">
-      <div class="row">
-        <div class="col-12">
-          <h1 class="title">
-            {{ article.title }}
-          </h1>
-          <h3 class="date">
-            <time pubdate datetime="{{ article.published_at | date: '%Y-%m-%d' }}">{{ article.published_at | date: '%b %d, %Y' }}</time>
-          </h3>
-        </div>
+<article>
+  <div class="p-strip--light">
+    <div class="row">
+      <div class="col-12">
+        <h1 class="title">
+          {{ article.title }}
+        </h1>
+        <h3 class="date">
+          <time pubdate datetime="{{ article.published_at | date: '%Y-%m-%d' }}">{{ article.published_at | date: '%b %d, %Y' }}</time>
+        </h3>
       </div>
     </div>
+  </div>
 
-    <div class="p-strip is-bordered">
-      <div class="u-fixed-width">
-        {{ article.content }}
-      </div>
-
-      {% if article.tags.size > 0 %}
-        <div class="u-fixed-width">
-          <ul class="p-inline-list">
-            {% for tag in article.tags %} 
-              <li class="p-inline-list__item" style="margin-right: 0;">
-                <a href="{{ blog.url }}/tagged/{{ tag | handle }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
-              </li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endif %}
+  <div class="p-strip is-bordered">
+    <div class="u-fixed-width">
+      {{ article.content }}
     </div>
-  </article>
 
-  {% if blog.next_article or blog.previous_article %}
-    <section class="p-strip is-shallow is-bordered">
+    {% if article.tags.size > 0 %}
       <div class="u-fixed-width">
-        <div class="p-article-pagination">
-          {% if blog.previous_article %}
-            <a class="p-article-pagination__link--previous" href="{{ blog.previous_article }}">
-              <span class="p-article-pagination__label">Previous article</span>
-            </a>
-          {% endif %}
-
-          {% if blog.next_article %}
-            <a class="p-article-pagination__link--next" href="{{ blog.next_article }}">
-              <span class="p-article-pagination__label">Next article</span>
-            </a>
-          {% endif %}
-        </div>
+        <ul class="p-inline-list">
+          {% for tag in article.tags %} 
+            <li class="p-inline-list__item" style="margin-right: 0;">
+              <a href="{{ blog.url }}/tagged/{{ tag | handle }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
+            </li>
+          {% endfor %}
+        </ul>
       </div>
-    </section>
-  {% endif %}
-</div>
+    {% endif %}
+  </div>
+</article>
+
+{% if blog.next_article or blog.previous_article %}
+  <section class="p-strip is-shallow is-bordered">
+    <div class="u-fixed-width">
+      <div class="p-article-pagination">
+        {% if blog.previous_article %}
+          <a class="p-article-pagination__link--previous" href="{{ blog.previous_article }}">
+            <span class="p-article-pagination__label">Previous article</span>
+          </a>
+        {% endif %}
+
+        {% if blog.next_article %}
+          <a class="p-article-pagination__link--next" href="{{ blog.next_article }}">
+            <span class="p-article-pagination__label">Next article</span>
+          </a>
+        {% endif %}
+      </div>
+    </div>
+  </section>
+{% endif %}

--- a/src/templates/article.liquid
+++ b/src/templates/article.liquid
@@ -1,160 +1,61 @@
-{% paginate article.comments by 50 %}
+{% comment %}Remove this script tag to reinstate article pages{% endcomment %}
+<script>
+	window.location.replace("{{ shop.url }}");
+</script>
 
-{% comment %}
-When a comment has just been submitted, it's not shown right away.
-Shopify needs to wait until it knows for sure that it is not spam to publish it.
-We can still show right away *to its author* the comment he just submitted 
-— although that comment may not have been published yet.
-When a comment is submitted, the browser is redirected to a page that 
-includes the new comment id in its URL. Example:
-http://shopname.myshopify.com/blogs/news/2022072-my-post?comment=3721372
-When a comment ID is specified in an article URL, that comment is accessible in the 
-template through a Liquid object called comment. 
-That comment is a full-fledged comment variable that has all the regular comment properties: 
-http://docs.shopify.com/themes/liquid-variables/comment.
-Note that comment.created_at will only be defined if the comment did not have any blank field 
-— was posted without error.
-{% endcomment %}
+{% include 'site-nav' %}
 
-{% assign number_of_comments = article.comments_count %}
-
-{% comment %}If a comment was just submitted, and it has no blank fields.{% endcomment %}
-{% if comment and comment.created_at %}
-  {% assign number_of_comments = article.comments_count | plus: 1 %}
-{% endif %}
-
-<h2 class="delta"><a href="{{ blog.url }}">{{ blog.title }}</a></h2>
-
-<div class="article">
-  <h1 class="title">
-    {{ article.title }}
-  </h1>
-  <h3 class="date">
-    <time pubdate datetime="{{ article.published_at | date: '%Y-%m-%d' }}">{{ article.published_at | date: '%b %d, %Y' }}</time>
-  </h3>
-  <div class="rte">
-    {{ article.content }}
-  </div>
-  <div class="meta">
-    {% if blog.comments_enabled? and article.comments_count > 0 %}
-    <span class="meta-comments">
-      <a href="#comments"><i class="fa fa-comment"></i> {{ article.comments_count }} {{ article.comments_count | pluralize: 'comment','comments' }}</a>
-    </span>
-    {% endif %}
-    {% if article.tags.size > 0 %}
-    <span class="tags">
-      {% for tag in article.tags %} 
-      <a href="{{ blog.url }}/tagged/{{ tag | handle }}">{% if forloop.first %}<i class="fa fa-tag"></i> {% endif %}{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
-      {% endfor %}
-    </span>
-    {% endif %}
-  </div>
-</div>
-
-{% if blog.comments_enabled? %}
-<div id="comments">
-
-  {% comment %}If a comment was just submitted with no blank field.{% endcomment %}
-  {% if comment and comment.created_at %}
-  <p class="success feedback">
-    {% if blog.moderated? %}
-    Your comment was posted successfully. We will publish it in a little while, as our blog is moderated.
-    {% else %}
-    Your comment was posted successfully! Thank you!
-    {% endif %}
-  </p>
-  {% endif %}
-
-  {% if number_of_comments > 0 %}
-  <ul>
-    {% comment %}If a comment was just submitted with no blank field, let's show it.{% endcomment %}
-    {% if comment and comment.created_at %}
-    <li id="{{ comment.id }}" class="comment first{% if article.comments_count == 0 %} last{% endif %}">
-      <h3 class="comment-author">{{ comment.author }} says...</h3>
-      <div class="comment-content">
-        {{ comment.content }}
+<div id="main-content" class="main" role="main">
+  <article>
+    <div class="p-strip--light">
+      <div class="row">
+        <div class="col-12">
+          <h1 class="title">
+            {{ article.title }}
+          </h1>
+          <h3 class="date">
+            <time pubdate datetime="{{ article.published_at | date: '%Y-%m-%d' }}">{{ article.published_at | date: '%b %d, %Y' }}</time>
+          </h3>
+        </div>
       </div>
-      <p class="comment-date">
-        On {{ comment.created_at | date: "%B %d, %Y" }}
-      </p>
-    </li>
-    {% endif %}
-    {% comment %}Showing the rest of the comments.{% endcomment %}
-    {% for comment in article.comments %}
-    <li id="{{ comment.id }}" class="comment{% unless number_of_comments > article.comments_count %}{% if forloop.first %} first{% endif %}{% endunless %}{% if forloop.last %} last {% endif %}">
-      <h3 class="comment-author">{{ comment.author }} says...</h3>
-      <div class="comment-content">
-        {{ comment.content }}
+    </div>
+
+    <div class="p-strip is-bordered">
+      <div class="u-fixed-width">
+        {{ article.content }}
       </div>
-      <p class="comment-date">
-        On {{ comment.created_at | date: "%B %d, %Y" }}
-      </p>
-    </li>
-    {% endfor %}
-  </ul>
-  {% endif %}
-  
-  {% comment %}Comments are paginated.{% endcomment %}
-  {% if paginate.pages > 1 %}
-  <div id="pagination">
-    {{ paginate | default_pagination }}
-  </div>
-  {% endif %}
-  
-  {% comment %}Comment submission form.{% endcomment %}
-  {% form "new_comment", article %}
-  
-  <h3 id="add-comment-title">Leave a comment</h3>
-  
-  {% if form.errors %}
-  <div class="feedback error">
-  {{ form.errors | default_errors }}
-  </div>
-  {% endif %}
 
-  <p>
-    <label for="comment-author">Name</label>
-    <input required{% if form.errors contains "author" %} class="error"{% endif %} type="text" name="comment[author]" placeholder="Your name" id="comment-author" value="{{ form.author }}" />
-  </p>
+      {% if article.tags.size > 0 %}
+        <div class="u-fixed-width">
+          <ul class="p-inline-list">
+            {% for tag in article.tags %} 
+              <li class="p-inline-list__item" style="margin-right: 0;">
+                <a href="{{ blog.url }}/tagged/{{ tag | handle }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+    </div>
+  </article>
 
-  <p>
-    <label for="comment-email">Email</label>
-    <input required{% if form.errors contains "email" %} class="error"{% endif %} type="email" name="comment[email]" placeholder="your@email.com" id="comment-email" value="{{ form.email }}" />
-  </p>
+  {% if blog.next_article or blog.previous_article %}
+    <section class="p-strip is-shallow is-bordered">
+      <div class="u-fixed-width">
+        <div class="p-article-pagination">
+          {% if blog.previous_article %}
+            <a class="p-article-pagination__link--previous" href="{{ blog.previous_article }}">
+              <span class="p-article-pagination__label">Previous article</span>
+            </a>
+          {% endif %}
 
-  <p>
-    <label for="comment-body">Message</label>
-    <textarea required{% if form.errors contains "body" %} class="error"{% endif %} name="comment[body]" id="comment-body">{{ form.body }}</textarea>
-  </p>
-
-  <input type="submit" value="Post Comment" /> 
-  
-  {% if form.errors %}
-    <script>
-      window.location.hash = '#add-comment-title';
-    </script>
+          {% if blog.next_article %}
+            <a class="p-article-pagination__link--next" href="{{ blog.next_article }}">
+              <span class="p-article-pagination__label">Next article</span>
+            </a>
+          {% endif %}
+        </div>
+      </div>
+    </section>
   {% endif %}
-  
-  {% if form.posted_successfully? %}
-    <script>
-      window.location.hash = '#comments';
-    </script>
-  {% endif %} 
-  
-  {% endform %}
-  
 </div>
-{% endif %}
-
-{% if blog.next_article or blog.previous_article %}
-<p class="clearfix"> 
-  {% if blog.next_article %}
-  <span class="left">{{ '&larr; Next Post' | link_to: blog.next_article }}</span>
-  {% endif %}    
-  {% if blog.previous_article %}
-  <span class="right">{{ 'Previous Post &rarr;' | link_to: blog.previous_article }}</span>
-  {% endif %}
-</p>
-{% endif %}
-
-{% endpaginate %}

--- a/src/templates/blog.liquid
+++ b/src/templates/blog.liquid
@@ -3,95 +3,91 @@
 	window.location.replace("{{ shop.url }}");
 </script>
 
-{% include 'site-nav' %}
+{% paginate blog.articles by 5 %}
 
-<div id="main-content" class="main" role="main">
-  {% paginate blog.articles by 5 %}
-
-  <section class="p-strip--light">
-    <div class="row">
-      <div class="col-12">
-        {% if current_tags %}
-          <h1>{{ blog.title | link_to: blog.url }}&nbsp;&raquo; {{ current_tags.first }}</h1>
-        {% else %}
-          <h1>{{ blog.title }}</h1>
-        {% endif %}
-      </div>
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-12">
+      {% if current_tags %}
+        <h1>{{ blog.title | link_to: blog.url }}&nbsp;&raquo; {{ current_tags.first }}</h1>
+      {% else %}
+        <h1>{{ blog.title }}</h1>
+      {% endif %}
     </div>
   </div>
-
-  <section class="p-strip is-bordered">
-    {% for article in blog.articles %}
-      
-    {% assign article_has_image = false %}
-    {% assign img_tag = '<' | append: 'img' %}
-    {% if article.excerpt_or_content contains img_tag %}
-      {% assign src = article.excerpt_or_content | split: 'src="' %}
-      {% assign src = src[1] | split: '"' | first %}
-      {% if src %}
-        {% assign article_has_image = true %}
-        {% assign image_src = src | replace: '_small', '' | replace: '_compact', '' | replace: '_medium', '' | replace: '_large', '' | replace: '_grande', '' %}
-      {% endif %}
-    {% endif %}  
-    
-    <div class="row">
-      <div class="col-12">
-        <h2>
-          <a href="{{ article.url }}">{{ article.title }}</a>
-        </h2>
-        <h3>
-          <time pubdate datetime="{{ article.published_at | date: '%Y-%m-%d' }}">{{ article.published_at | date: '%b %d, %Y' }}</time>
-        </h3>
-        <div class="row">
-          {% if article_has_image %}
-          <div class="col-3">
-            <a href="{{ article.url }}">
-              <span style="background-image: url({{ image_src }})">
-              </span>
-            </a>
-          </div>
-          <div class="col-9">         
-          {% else %}
-          <div class="col-12">
-          {% endif %}    
-
-            {% if article.excerpt.size > 0 %}
-              <div>{{ article.excerpt }}</div>
-            {% else %}
-              <p>{{ article.content | strip_html | truncatewords: 120 }}</p>
-            {% endif %}
-          </div>
-        
-          <p>
-            <a href="{{ article.url }}">Read more →</a>
-          </p>
-        </div>
-      </div>
-    </div>
-      {% if article.tags.size > 0 %}
-        <div class="row">
-          <div class="col-12">
-            <ul class="p-inline-list">
-              {% for tag in article.tags %}
-                <li class="p-inline-list__item" style="margin-right: 0;">
-                  <a href="{{ blog.url }}/tagged/{{ tag | handle }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
-                </li>
-              {% endfor %}
-            </ul>
-          </div>
-        </div>
-      {% endif %}
-      {% unless forloop.last %}
-        <div class="u-fixed-width">
-          <hr />
-        </div>
-      {% endunless %}
-    {% endfor %}
-  </div>
-    
-  {% if paginate.pages > 1 %}
-    <div class="pagination">
-    {{ paginate | default_pagination | replace: 'Previous', 'Newer articles' | replace: 'Next', 'Older articles' }}
-  {% endif %}
-  {% endpaginate %}
 </div>
+
+<section class="p-strip is-bordered">
+  {% for article in blog.articles %}
+    
+  {% assign article_has_image = false %}
+  {% assign img_tag = '<' | append: 'img' %}
+  {% if article.excerpt_or_content contains img_tag %}
+    {% assign src = article.excerpt_or_content | split: 'src="' %}
+    {% assign src = src[1] | split: '"' | first %}
+    {% if src %}
+      {% assign article_has_image = true %}
+      {% assign image_src = src | replace: '_small', '' | replace: '_compact', '' | replace: '_medium', '' | replace: '_large', '' | replace: '_grande', '' %}
+    {% endif %}
+  {% endif %}  
+  
+  <div class="row">
+    <div class="col-12">
+      <h2>
+        <a href="{{ article.url }}">{{ article.title }}</a>
+      </h2>
+      <h3>
+        <time pubdate datetime="{{ article.published_at | date: '%Y-%m-%d' }}">{{ article.published_at | date: '%b %d, %Y' }}</time>
+      </h3>
+      <div class="row">
+        {% if article_has_image %}
+        <div class="col-3">
+          <a href="{{ article.url }}">
+            <span style="background-image: url({{ image_src }})">
+            </span>
+          </a>
+        </div>
+        <div class="col-9">         
+        {% else %}
+        <div class="col-12">
+        {% endif %}    
+
+          {% if article.excerpt.size > 0 %}
+            <div>{{ article.excerpt }}</div>
+          {% else %}
+            <p>{{ article.content | strip_html | truncatewords: 120 }}</p>
+          {% endif %}
+        </div>
+      
+        <p>
+          <a href="{{ article.url }}">Read more →</a>
+        </p>
+      </div>
+    </div>
+  </div>
+    {% if article.tags.size > 0 %}
+      <div class="row">
+        <div class="col-12">
+          <ul class="p-inline-list">
+            {% for tag in article.tags %}
+              <li class="p-inline-list__item" style="margin-right: 0;">
+                <a href="{{ blog.url }}/tagged/{{ tag | handle }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    {% endif %}
+    {% unless forloop.last %}
+      <div class="u-fixed-width">
+        <hr />
+      </div>
+    {% endunless %}
+  {% endfor %}
+</div>
+  
+{% if paginate.pages > 1 %}
+  <div class="pagination">
+  {{ paginate | default_pagination | replace: 'Previous', 'Newer articles' | replace: 'Next', 'Older articles' }}
+{% endif %}
+{% endpaginate %}

--- a/src/templates/blog.liquid
+++ b/src/templates/blog.liquid
@@ -1,92 +1,97 @@
-{% paginate blog.articles by 5 %}
+{% comment %}Remove this script tag to reinstate the blog index{% endcomment %}
+<script>
+	window.location.replace("{{ shop.url }}");
+</script>
 
-{% if current_tags %}
-<h1 class="delta">{{ blog.title | link_to: blog.url }} <span class="quiet">&raquo;</span> {{ current_tags.first }}</h1>
-{% else %}
-<h1 class="delta">{{ blog.title }}</h1>
-{% endif %}
+{% include 'site-nav' %}
 
-<div class="articles">
+<div id="main-content" class="main" role="main">
+  {% paginate blog.articles by 5 %}
 
-  {% for article in blog.articles %}
-  
-  {% comment %}
-    Let's extract a blog image.
-    We will look for an image in the excerpt first, and in the blog post itself second.
-    We will remove the image suffix to grab as big an image as we can.
-  {% endcomment %}
-    
-  {% assign article_has_image = false %}
-  {% assign img_tag = '<' | append: 'img' %}
-  {% if article.excerpt_or_content contains img_tag %}
-    {% assign src = article.excerpt_or_content | split: 'src="' %}
-    {% assign src = src[1] | split: '"' | first %}
-    {% if src %}
-      {% assign article_has_image = true %}
-      {% assign image_src = src | replace: '_small', '' | replace: '_compact', '' | replace: '_medium', '' | replace: '_large', '' | replace: '_grande', '' %}
-    {% endif %}
-  {% endif %}  
-  
-  <div class="article{% if forloop.first %} first{% endif %}{% if forloop.last %} last{% endif %} clear">
-    <h2 class="title">
-      <a href="{{ article.url }}">{{ article.title }}</a>
-    </h2>
-    <h3 class="date">
-      <time pubdate datetime="{{ article.published_at | date: '%Y-%m-%d' }}">{{ article.published_at | date: '%b %d, %Y' }}</time>
-    </h3>
+  <section class="p-strip--light">
     <div class="row">
-      {% if article_has_image %}
-      <div class="third column">
-        <a href="{{ article.url }}">
-          <span class="square-holder" style="background-image: url({{ image_src }})">
-          </span>
-        </a>
-      </div>
-      <div class="two-thirds column">
-        <div class="rte fadeout-overflow-bottom grid-margins">          
-      {% else %}
-      <div class="full column">
-        <div class="rte">
-      {% endif %}        
-          {% if article.excerpt.size > 0 %}
-          <div class="no-images">{{ article.excerpt }}</div>
-          {% else %}
-          <p>{{ article.content | strip_html | truncatewords: 120 }}</p>
-          {% endif %}
-        </div>
-        <p>
-          <a class="blog-read-more" href="{{ article.url }}">Read more →</a>
-        </p>
+      <div class="col-12">
+        {% if current_tags %}
+          <h1>{{ blog.title | link_to: blog.url }}&nbsp;&raquo; {{ current_tags.first }}</h1>
+        {% else %}
+          <h1>{{ blog.title }}</h1>
+        {% endif %}
       </div>
     </div>
-    <div class="meta">
-      {% if blog.comments_enabled? and article.comments_count > 0 %}
-      <span class="meta-comments">
-        <a href="{{ article.url }}#comments"><i class="fa fa-comment"></i> {{ article.comments_count }} {{ article.comments_count | pluralize: 'comment','comments' }}</a>
-      </span>
-      {% endif %}
-      {% if article.tags.size > 0 %}
-      <span class="tags">
-        {% for tag in article.tags %} 
-        <a href="{{ blog.url }}/tagged/{{ tag | handle }}">{% if forloop.first %}<i class="fa fa-tag"></i> {% endif %}{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
-        {% endfor %}
-      </span>
-      {% endif %}
   </div>
-</div>
-  
-{% endfor %}
 
-</div>
-  
-{% if paginate.pages > 1 %}
-<div class="pagination">
-{% comment %}
-  When paginating blog articles, a previous article is actually a newer article, not an older one,
-  because blog articles are shown and paginated in a reversed chronological order.
-  The word 'previous' can be confusing, hence we'll change it.
-{% endcomment %}
-{{ paginate | default_pagination | replace: 'Previous', 'Newer articles' | replace: 'Next', 'Older articles' }}
-{% endif %}
+  <section class="p-strip is-bordered">
+    {% for article in blog.articles %}
+      
+    {% assign article_has_image = false %}
+    {% assign img_tag = '<' | append: 'img' %}
+    {% if article.excerpt_or_content contains img_tag %}
+      {% assign src = article.excerpt_or_content | split: 'src="' %}
+      {% assign src = src[1] | split: '"' | first %}
+      {% if src %}
+        {% assign article_has_image = true %}
+        {% assign image_src = src | replace: '_small', '' | replace: '_compact', '' | replace: '_medium', '' | replace: '_large', '' | replace: '_grande', '' %}
+      {% endif %}
+    {% endif %}  
+    
+    <div class="row">
+      <div class="col-12">
+        <h2>
+          <a href="{{ article.url }}">{{ article.title }}</a>
+        </h2>
+        <h3>
+          <time pubdate datetime="{{ article.published_at | date: '%Y-%m-%d' }}">{{ article.published_at | date: '%b %d, %Y' }}</time>
+        </h3>
+        <div class="row">
+          {% if article_has_image %}
+          <div class="col-3">
+            <a href="{{ article.url }}">
+              <span style="background-image: url({{ image_src }})">
+              </span>
+            </a>
+          </div>
+          <div class="col-9">         
+          {% else %}
+          <div class="col-12">
+          {% endif %}    
 
-{% endpaginate %}
+            {% if article.excerpt.size > 0 %}
+              <div>{{ article.excerpt }}</div>
+            {% else %}
+              <p>{{ article.content | strip_html | truncatewords: 120 }}</p>
+            {% endif %}
+          </div>
+        
+          <p>
+            <a href="{{ article.url }}">Read more →</a>
+          </p>
+        </div>
+      </div>
+    </div>
+      {% if article.tags.size > 0 %}
+        <div class="row">
+          <div class="col-12">
+            <ul class="p-inline-list">
+              {% for tag in article.tags %}
+                <li class="p-inline-list__item" style="margin-right: 0;">
+                  <a href="{{ blog.url }}/tagged/{{ tag | handle }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+      {% endif %}
+      {% unless forloop.last %}
+        <div class="u-fixed-width">
+          <hr />
+        </div>
+      {% endunless %}
+    {% endfor %}
+  </div>
+    
+  {% if paginate.pages > 1 %}
+    <div class="pagination">
+    {{ paginate | default_pagination | replace: 'Previous', 'Newer articles' | replace: 'Next', 'Older articles' }}
+  {% endif %}
+  {% endpaginate %}
+</div>

--- a/src/templates/cart.liquid
+++ b/src/templates/cart.liquid
@@ -1,128 +1,124 @@
-{% include 'site-nav' %}
+{% include 'header' %}
 
-<div id="main-content" class="main shopping-cart" role="main">
-  {% include 'header' %}
+{% if cart.item_count > 0 %}
+  <section class="p-strip is-bordered is-shallow shopping-cart" style="background-color: #f1f1f1;">
+    <div class="row">
+      <div class="col-12">
+        <form action="/cart" method="post">
+          <ul class="p-list u-sv2">
+            {% for item in cart.items %}
+              {% assign collection_url = item.product.collections.last.url %}
+              {% if collection_url == '/collections/frontpage' or collection_url == blank %}
+                {% assign collection_url = '/collections/all' %}
+              {% endif %}
 
-  {% if cart.item_count > 0 %}
-    <section class="p-strip is-bordered is-shallow" style="background-color: #f1f1f1;">
-      <div class="row">
-        <div class="col-12">
-          <form action="/cart" method="post">
-            <ul class="p-list u-sv2">
-              {% for item in cart.items %}
-                {% assign collection_url = item.product.collections.last.url %}
-                {% if collection_url == '/collections/frontpage' or collection_url == blank %}
-                  {% assign collection_url = '/collections/all' %}
+              {% if forloop.first %}
+                {% assign continue_shopping_url = collection_url %}
+              {% endif %}
+
+              {% assign min_purchase = '1'  %}
+              {% for tag in item.product.tags %}
+                {% if tag contains 'min-purchase' %}
+                  {% assign min_purchase = tag | remove: 'min-purchase-' %}
+                {% endif %}
+              {% endfor %}
+
+              {% assign min_increment = '1'  %}
+              {% assign min_quantity = '1'  %}
+
+              {% for tag in item.product.tags %}
+                {% if tag contains 'increment-by' %}
+                  {% assign min_increment = tag | remove: 'increment-by-' %}
+                {% elsif tag contains 'min-purchase-10' %}
+                  {% assign min_quantity = '10' %}
+                {% elsif tag contains 'min-purchase-20' %}
+                  {% assign min_quantity = '20' %}
+                {% endif %}
+              {% endfor %}
+
+              <li class="p-card--highlighted cart_item" data-increment-amount="{{ min_increment }}" data-min-amount="{{ min_purchase }}" data-product-index="{{ forloop.index }}">
+                {% assign product_icon = 'icon-' %}
+                {% if item.title contains 'Desktop' %}
+                  {% assign product_icon = product_icon | append: 'desktop.png' %}
+                {% elsif item.title contains 'Server' %}
+                  {% assign product_icon = product_icon | append: 'servers.png' %}
+                {% elsif item.title contains 'Guest' %}
+                  {% assign product_icon = product_icon | append: 'vguests.png' %}
                 {% endif %}
 
-                {% if forloop.first %}
-                  {% assign continue_shopping_url = collection_url %}
-                {% endif %}
+                <div class="row u-vertically-center">
+                  <div class="col-2 u-hide--small">
+                    <img src="{{ product_icon | asset_url }}" alt="{{ item.title }}">
+                  </div>
+                  
+                  <div class="col-8">
+                    <h2><a href="{{ collection_url }}" title="{{ item.title }}">{{ item.title }}</a></h2>
+                    <h3>{{ item.line_price | money_with_currency }}</h3>
+                  </div>
 
-                {% assign min_purchase = '1'  %}
-                {% for tag in item.product.tags %}
-                  {% if tag contains 'min-purchase' %}
-                    {% assign min_purchase = tag | remove: 'min-purchase-' %}
-                  {% endif %}
-                {% endfor %}
+                  <div class="col-2 col-medium-4 col-start-medium-3">
+                    <ul class="p-inline-grid u-align--center cart_item--qty">
+                      <li>
+                        <span class="p-inline-grid__cta decrement" style="line-height: 2.2rem; display: block;">
+                          <i class="p-icon--minus"></i>
+                        </span>
+                      </li>
 
-                {% assign min_increment = '1'  %}
-                {% assign min_quantity = '1'  %}
+                      <li>
+                        <input class="cart_item--input" type="number" value="{{ item.quantity }}" step="{{ min_increment }}" min="{{ min_purchase }}" readonly required>
+                      </li>
 
-                {% for tag in item.product.tags %}
-                  {% if tag contains 'increment-by' %}
-                    {% assign min_increment = tag | remove: 'increment-by-' %}
-                  {% elsif tag contains 'min-purchase-10' %}
-                    {% assign min_quantity = '10' %}
-                  {% elsif tag contains 'min-purchase-20' %}
-                    {% assign min_quantity = '20' %}
-                  {% endif %}
-                {% endfor %}
+                      <li>
+                        <span class="p-inline-grid__cta increment" style="line-height: 2.2rem; display: block;">
+                          <i class="p-icon--plus"></i>
+                        </span>
+                      </li>
+                    </ul>
 
-                <li class="p-card--highlighted cart_item" data-increment-amount="{{ min_increment }}" data-min-amount="{{ min_purchase }}" data-product-index="{{ forloop.index }}">
-                  {% assign product_icon = 'icon-' %}
-                  {% if item.title contains 'Desktop' %}
-                    {% assign product_icon = product_icon | append: 'desktop.png' %}
-                  {% elsif item.title contains 'Server' %}
-                    {% assign product_icon = product_icon | append: 'servers.png' %}
-                  {% elsif item.title contains 'Guest' %}
-                    {% assign product_icon = product_icon | append: 'vguests.png' %}
-                  {% endif %}
+                    {% if min_quantity != '1' %}
+                      <small class="u-float-right u-no-margin--bottom">Minimum order: {{ min_quantity }}</small>
+                    {% endif %}
 
-                  <div class="row u-vertically-center">
-                    <div class="col-2 u-hide--small">
-                      <img src="{{ product_icon | asset_url }}" alt="{{ item.title }}">
-                    </div>
-                    
-                    <div class="col-8">
-                      <h2><a href="{{ collection_url }}" title="{{ item.title }}">{{ item.title }}</a></h2>
-                      <h3>{{ item.line_price | money_with_currency }}</h3>
-                    </div>
-
-                    <div class="col-2 col-medium-4 col-start-medium-3">
-                      <ul class="p-inline-grid u-align--center cart_item--qty">
-                        <li>
-                          <span class="p-inline-grid__cta decrement" style="line-height: 2.2rem; display: block;">
-                            <i class="p-icon--minus"></i>
-                          </span>
-                        </li>
-
-                        <li>
-                          <input class="cart_item--input" type="number" value="{{ item.quantity }}" step="{{ min_increment }}" min="{{ min_purchase }}" readonly required>
-                        </li>
-
-                        <li>
-                          <span class="p-inline-grid__cta increment" style="line-height: 2.2rem; display: block;">
-                            <i class="p-icon--plus"></i>
-                          </span>
-                        </li>
-                      </ul>
-
-                      {% if min_quantity != '1' %}
-                        <small class="u-float-right u-no-margin--bottom">Minimum order: {{ min_quantity }}</small>
-                      {% endif %}
-
-                      <div class="row u-align--right">
-                        <div class="col-2">
-                          <a href="/cart/change?line={{ forloop.index }}&quantity=0" class="p-muted-heading" style="color: #666; display: block; margin-top: 1rem;">Remove</a>
-                        </div>
+                    <div class="row u-align--right">
+                      <div class="col-2">
+                        <a href="/cart/change?line={{ forloop.index }}&quantity=0" class="p-muted-heading" style="color: #666; display: block; margin-top: 1rem;">Remove</a>
                       </div>
                     </div>
                   </div>
-                </li>
-              {% endfor %}
-            </ul>
-
-            <div class="row">
-              <div class="col-6">
-                {% if settings.cart_promo_toggle %}
-                  <div class="row u-sv3">
-                    <div class="col-1 col-small-1 col-medium-1">
-                      <img src="{{ 'cart_promo_img.png' | asset_url }}" alt="{{ settings.cart_promo__heading }}" />
-                    </div>
-                    <div class="col-5 col-small-3 col-medium-5">
-                      <h3 class="p-heading--four">{{ settings.cart_promo_heading }}</h3>
-                      <p>{{ settings.cart_promo_copy }}</p>
-                      <a href="{{ settings.cart_promo_link }}">{{ settings.cart_promo_link_copy }} ›</a>
-                    </div>
-                  </div>
-                  <hr class="u-hide--medium u-hide--large" />
-                {% endif %}
-              </div>
-
-              <div class="col-5 col-start-large-9">
-                <div class="u-clearfix">
-                  <h3 class="p-heading--four u-float-left">Subtotal:</h3>
-                  <span class="p-heading--three u-float-right">{{ cart.total_price | money }}</span>
                 </div>
-                <input type="checkbox" id="agree_to_tac" name=="agree_to_tac" required><label for="agree_to_tac" style="margin-bottom: 1rem;">{{ settings.tac_copy }}</label>
-                <button class="p-button--positive p-button--shop-cta u-no-margin--bottom" type="submit">Check out</button>
-                <a class="p-button--neutral p-button--shop-cta" href="/">Continue shopping</a>
-              </div>
+              </li>
+            {% endfor %}
+          </ul>
+
+          <div class="row">
+            <div class="col-6">
+              {% if settings.cart_promo_toggle %}
+                <div class="row u-sv3">
+                  <div class="col-1 col-small-1 col-medium-1">
+                    <img src="{{ 'cart_promo_img.png' | asset_url }}" alt="{{ settings.cart_promo__heading }}" />
+                  </div>
+                  <div class="col-5 col-small-3 col-medium-5">
+                    <h3 class="p-heading--four">{{ settings.cart_promo_heading }}</h3>
+                    <p>{{ settings.cart_promo_copy }}</p>
+                    <a href="{{ settings.cart_promo_link }}">{{ settings.cart_promo_link_copy }} ›</a>
+                  </div>
+                </div>
+                <hr class="u-hide--medium u-hide--large" />
+              {% endif %}
             </div>
-          </form>
-        </div>
+
+            <div class="col-5 col-start-large-9">
+              <div class="u-clearfix">
+                <h3 class="p-heading--four u-float-left">Subtotal:</h3>
+                <span class="p-heading--three u-float-right">{{ cart.total_price | money }}</span>
+              </div>
+              <input type="checkbox" id="agree_to_tac" name=="agree_to_tac" required><label for="agree_to_tac" style="margin-bottom: 1rem;">{{ settings.tac_copy }}</label>
+              <button class="p-button--positive p-button--shop-cta u-no-margin--bottom" type="submit">Check out</button>
+              <a class="p-button--neutral p-button--shop-cta" href="/">Continue shopping</a>
+            </div>
+          </div>
+        </form>
       </div>
-    </section>
-  {% endif %}
-</div>
+    </div>
+  </section>
+{% endif %}

--- a/src/templates/cart.liquid
+++ b/src/templates/cart.liquid
@@ -112,8 +112,10 @@
                 <h3 class="p-heading--four u-float-left">Subtotal:</h3>
                 <span class="p-heading--three u-float-right">{{ cart.total_price | money }}</span>
               </div>
-              <input type="checkbox" id="agree_to_tac" name=="agree_to_tac" required><label for="agree_to_tac" style="margin-bottom: 1rem;">{{ settings.tac_copy }}</label>
-              <button class="p-button--positive p-button--shop-cta u-no-margin--bottom" type="submit">Check out</button>
+              <input type="checkbox" id="agree_to_tac" name="agree_to_tac" required><label for="agree_to_tac" style="margin-bottom: 1rem;">{{ settings.tac_copy }}</label>
+
+              {% comment %}For the checkout button to work, it needs to use a name attribute set to 'checkout'.{% endcomment %}
+              <button class="p-button--positive p-button--shop-cta u-no-margin--bottom" name="checkout" type="submit">Check out</button>
               <a class="p-button--neutral p-button--shop-cta" href="/">Continue shopping</a>
             </div>
           </div>

--- a/src/templates/collection.liquid
+++ b/src/templates/collection.liquid
@@ -1,46 +1,28 @@
-{% include 'site-nav' %}
+{% if collection.handle == settings.collection_one_hero %}
+  {% assign bgcolor = settings.collection_one_hero_bgcolor %}
+  {% assign txcolor = settings.collection_one_hero_textcolor %}
+{% elsif collection.handle == settings.collection_two_hero %}
+  {% assign bgcolor = settings.collection_two_hero_bgcolor %}
+  {% assign txcolor = settings.collection_two_hero_textcolor %}
+{% elsif collection.handle  == settings.collection_three_hero %}
+  {% assign bgcolor = settings.collection_three_hero_bgcolor %}
+  {% assign txcolor = settings.collection_three_hero_textcolor %}
+{% else %}
+  {% assign bgcolor = settings.collection_hero_bgcolor %}
+  {% assign txcolor = settings.collection_hero_textcolor %}
+{% endif %}
 
-<div id="main-content" class="main" role="main">
-  {% if collection.handle == settings.collection_one_hero %}
-    {% assign bgcolor = settings.collection_one_hero_bgcolor %}
-    {% assign txcolor = settings.collection_one_hero_textcolor %}
-  {% elsif collection.handle == settings.collection_two_hero %}
-    {% assign bgcolor = settings.collection_two_hero_bgcolor %}
-    {% assign txcolor = settings.collection_two_hero_textcolor %}
-  {% elsif collection.handle  == settings.collection_three_hero %}
-    {% assign bgcolor = settings.collection_three_hero_bgcolor %}
-    {% assign txcolor = settings.collection_three_hero_textcolor %}
-  {% else %}
-    {% assign bgcolor = settings.collection_hero_bgcolor %}
-    {% assign txcolor = settings.collection_hero_textcolor %}
-  {% endif %}
+{% include 'header' %}
 
-  {% include 'header' %}
-
-  <section class="p-strip is-shallow is-bordered" style="background-color: {{ bgcolor }};">
-    <div class="row u-equal-height">
-      {% for product in collection.products %}
-        <div class="col-4 p-card--highlighted">
-          <h2>{{ product.title }}</h2>
-          <h3 style="color: #2c001e;">{{ product.price | money_with_currency }} <small>{{ settings.home_featured_pricing }}</small></h3>
-          {% if product.available %}
-            {% if product.variants.size > 1 %}
-              {% for variant in product.variants %}
-                {% assign min_purchase = '1'  %}
-                
-                {% for tag in product.tags %}
-                  {% if tag contains 'min-purchase' %}
-                    {% assign min_purchase = tag | remove: 'min-purchase-' %}
-                  {% endif %}
-                {% endfor %}
-                
-                <form action="/cart/add" method="post">
-                  <input type="hidden" name="id" value="{{ variant.id }}">
-                  <input type="hidden" name="quantity" value="{{ min_purchase }}">
-                  <button type="submit" class="p-button--positive p-button--shop-cta">Add to Cart</button>
-                </form>
-              {% endfor %}
-            {% else %}
+<section class="p-strip is-shallow is-bordered" style="background-color: {{ bgcolor }};">
+  <div class="row u-equal-height">
+    {% for product in collection.products %}
+      <div class="col-4 p-card--highlighted">
+        <h2>{{ product.title }}</h2>
+        <h3 style="color: #2c001e;">{{ product.price | money_with_currency }} <small>{{ settings.home_featured_pricing }}</small></h3>
+        {% if product.available %}
+          {% if product.variants.size > 1 %}
+            {% for variant in product.variants %}
               {% assign min_purchase = '1'  %}
               
               {% for tag in product.tags %}
@@ -48,24 +30,38 @@
                   {% assign min_purchase = tag | remove: 'min-purchase-' %}
                 {% endif %}
               {% endfor %}
+              
               <form action="/cart/add" method="post">
-                <input type="hidden" name="id" value="{{ product.variants.first.id }}">
+                <input type="hidden" name="id" value="{{ variant.id }}">
                 <input type="hidden" name="quantity" value="{{ min_purchase }}">
                 <button type="submit" class="p-button--positive p-button--shop-cta">Add to Cart</button>
-                {{ product.metafields.global.CTApostscript }}
               </form>
-            {% endif %}
+            {% endfor %}
+          {% else %}
+            {% assign min_purchase = '1'  %}
+            
+            {% for tag in product.tags %}
+              {% if tag contains 'min-purchase' %}
+                {% assign min_purchase = tag | remove: 'min-purchase-' %}
+              {% endif %}
+            {% endfor %}
+            <form action="/cart/add" method="post">
+              <input type="hidden" name="id" value="{{ product.variants.first.id }}">
+              <input type="hidden" name="quantity" value="{{ min_purchase }}">
+              <button type="submit" class="p-button--positive p-button--shop-cta">Add to Cart</button>
+              {{ product.metafields.global.CTApostscript }}
+            </form>
           {% endif %}
+        {% endif %}
 
-          {{ product.description | replace: '<ul>', '<ul class="p-list">' | replace: '<li>**', '<li>' | replace: '<li>', '<li class="p-list__item p-list__item--tall is-ticked">' | replace: '<p>', '<p class="p-product-description">' }}
+        {{ product.description | replace: '<ul>', '<ul class="p-list">' | replace: '<li>**', '<li>' | replace: '<li>', '<li class="p-list__item p-list__item--tall is-ticked">' | replace: '<p>', '<p class="p-product-description">' }}
+      </div>
+    {% else %}
+      <div class="row">
+        <div class="col-12">
+          <p>There are no products in this view.</p>
         </div>
-      {% else %}
-        <div class="row">
-          <div class="col-12">
-            <p>There are no products in this view.</p>
-          </div>
-        </div>
-      {% endfor %}
-    </div>
-  </section>
-</div>
+      </div>
+    {% endfor %}
+  </div>
+</section>

--- a/src/templates/index.liquid
+++ b/src/templates/index.liquid
@@ -11,7 +11,6 @@
         {% unless settings.homepage_page == blank or pages[settings.homepage_page].empty? %}
         {% assign page = pages[settings.homepage_page] %}
           {{ page.content | replace: '<ul>', '<ul class="p-list">' | replace: '<li>**', '<li class="p-list__item is-ticked">' }}
-          </ul>
         {% endunless %}
       </div>
       <div class="col-5">
@@ -60,7 +59,7 @@
             </div>
             <div class="col-3 col-small-3 col-medium-3">
               <h4>{{ collect_three.metafields.c_f['[c]Homepage title'] }}&nbsp;&rsaquo;</h4>
-              <h5>{{ collect_three.metafields.c_f['[c]Collection Price'] | money_without_trailing_zeros }}</span> {{ settings.home_featured_pricing }}</h5>
+              <h5>{{ collect_three.metafields.c_f['[c]Collection Price'] | money_without_trailing_zeros }} {{ settings.home_featured_pricing }}</h5>
               {% unless settings.home_featured_collection_three_desc == blank or settings.home_featured_collection_three_desc.empty? %}
               <h6>{{ settings.home_featured_collection_three_desc }}</h6>
               {% endunless %}
@@ -90,68 +89,67 @@
     <div class="u-fixed-width">
       <h2 class="p-muted-heading u-align--center" style="max-width: none;">{{ settings.home_customers_heading }}</h2>
       <ul class="p-inline-images">
-
         <li class="p-inline-images__item">
         {% if settings.link_customer_one == true %}
-          <a href="{{ settings.link_customer_one_url | url_escape }}"><img src="{{ 'logo-bloomberg.png' | asset_url }}"></a>
+          <a href="{{ settings.link_customer_one_url | url_escape }}"><img src="{{ 'logo-bloomberg.png' | asset_url }}" alt="Bloomberg logo" /></a>
         {% else %}
-          <img src="{{ 'logo-bloomberg.png' | asset_url }}">
+          <img src="{{ 'logo-bloomberg.png' | asset_url }}"  alt="Bloomberg logo" />
         {% endif %}
         </li>
 
         <li class="p-inline-images__item">
         {% if settings.link_customer_two == true %}
-          <a href="{{ settings.link_customer_two_url | url_escape }}"><img src="{{ 'logo-att.png' | asset_url }}"></a>
+          <a href="{{ settings.link_customer_two_url | url_escape }}"><img src="{{ 'logo-att.png' | asset_url }}" alt="AT&T logo" /></a>
         {% else %}
-          <img src="{{ 'logo-att.png' | asset_url }}">
+          <img src="{{ 'logo-att.png' | asset_url }}" alt="AT&T logo" />
         {% endif %}
         </li>
 
         <li class="p-inline-images__item">
         {% if settings.link_customer_three == true %}
-          <a href="{{ settings.link_customer_three_url | url_escape }}"><img src="{{ 'logo-walmart.png' | asset_url }}"></a>
+          <a href="{{ settings.link_customer_three_url | url_escape }}"><img src="{{ 'logo-walmart.png' | asset_url }}" alt="Walmart logo" /></a>
         {% else %}
-          <img src="{{ 'logo-walmart.png' | asset_url }}">
+          <img src="{{ 'logo-walmart.png' | asset_url }}" alt="Walmart logo" />
         {% endif %}
         </li>
 
         <li class="p-inline-images__item">
         {% if settings.link_customer_four == true %}
-          <a href="{{ settings.link_customer_four_url | url_escape }}"><img src="{{ 'logo-tmobile.png' | asset_url }}"></a>
+          <a href="{{ settings.link_customer_four_url | url_escape }}"><img src="{{ 'logo-tmobile.png' | asset_url }}" alt="T-Mobile logo" /></a>
         {% else %}
-          <img src="{{ 'logo-tmobile.png' | asset_url }}">
+          <img src="{{ 'logo-tmobile.png' | asset_url }}" alt="T-Mobile logo" />
         {% endif %}
         </li>
 
         <li class="p-inline-images__item">
         {% if settings.link_customer_five == true %}
-          <a href="{{ settings.link_customer_five_url | url_escape }}"><img src="{{ 'logo-ebay.png' | asset_url }}"></a>
+          <a href="{{ settings.link_customer_five_url | url_escape }}"><img src="{{ 'logo-ebay.png' | asset_url }}" alt="Ebay logo" /></a>
         {% else %}
-          <img src="{{ 'logo-ebay.png' | asset_url }}">
+          <img src="{{ 'logo-ebay.png' | asset_url }}" alt="Ebay logo" />
         {% endif %}
         </li>
 
         <li class="p-inline-images__item">
         {% if settings.link_customer_six == true %}
-          <a href="{{ settings.link_customer_six_url | url_escape }}"><img src="{{ 'logo-cisco.png' | asset_url }}"></a>
+          <a href="{{ settings.link_customer_six_url | url_escape }}"><img src="{{ 'logo-cisco.png' | asset_url }}" alt="Cisco logo" /></a>
         {% else %}
-          <img src="{{ 'logo-cisco.png' | asset_url }}">
+          <img src="{{ 'logo-cisco.png' | asset_url }}" alt="Cisco logo" />
         {% endif %}
         </li>
 
         <li class="p-inline-images__item">
         {% if settings.link_customer_seven == true %}
-          <a href="{{ settings.link_customer_seven_url | url_escape }}"><img src="{{ 'logo-ntt.png' | asset_url }}"></a>
+          <a href="{{ settings.link_customer_seven_url | url_escape }}"><img src="{{ 'logo-ntt.png' | asset_url }}" alt="NTT logo" /></a>
         {% else %}
-          <img src="{{ 'logo-ntt.png' | asset_url }}">
+          <img src="{{ 'logo-ntt.png' | asset_url }}" alt="NTT logo" />
         {% endif %}
         </li>
 
         <li class="p-inline-images__item">
         {% if settings.link_customer_eight == true %}
-          <a href="{{ settings.link_customer_eight_url | url_escape }}"><img src="{{ 'logo-bestbuy.png' | asset_url }}"></a>
+          <a href="{{ settings.link_customer_eight_url | url_escape }}"><img src="{{ 'logo-bestbuy.png' | asset_url }}" alt="Best Buy logo" /></a>
         {% else %}
-          <img src="{{ 'logo-bestbuy.png' | asset_url }}">
+          <img src="{{ 'logo-bestbuy.png' | asset_url }}" alt="Best Buy logo" />
         {% endif %}
         </li>
 

--- a/src/templates/index.liquid
+++ b/src/templates/index.liquid
@@ -1,174 +1,170 @@
-{% include 'site-nav' %}
+{% include 'header' %}
 
-<div id="main-content" class="main" role="main">
-  {% include 'header' %}
-
-  <section class="p-strip--light">
-    <div class="row">
-      <div class="col-7">
-        <h3>{{ settings.home_featured_heading }}</h3>
-        <p>{{ settings.home_featured_description }}</p>
-        {% unless settings.homepage_page == blank or pages[settings.homepage_page].empty? %}
-        {% assign page = pages[settings.homepage_page] %}
-          {{ page.content | replace: '<ul>', '<ul class="p-list">' | replace: '<li>**', '<li class="p-list__item is-ticked">' }}
-        {% endunless %}
-      </div>
-      <div class="col-5">
-        {% if settings.home_featured_collection_one %}
-        {% assign collect_one = collections[settings.home_featured_collection_one] %}
-        <div class="p-card--highlighted">
-          <a href="{{ collect_one.url }}" class="row u-equal-height u-vertically-center">
-            <div class="col-2 col-small-1 col-medium-2">
-              <img src="{{ 'icon-collection-1.png' | asset_url }}" alt="{{ collect_one.title }}">
-            </div>
-            <div class="col-3 col-small-3 col-medium-3">
-              <h4>{{ collect_one.metafields.c_f['[c]Homepage title'] }}&nbsp;&rsaquo;</h4>
-              <h5>{{ collect_one.metafields.c_f['[c]Collection Price'] | money_without_trailing_zeros }} {{ settings.home_featured_pricing }}</h5>
-              {% unless settings.home_featured_collection_one_desc == blank or settings.home_featured_collection_one_desc.empty? %}
-              <h6>{{ settings.home_featured_collection_one_desc }}</h6>
-              {% endunless %}
-            </div>
-          </a>
-        </div>
-        {% endif %}
-
-        {% if settings.home_featured_collection_two %}
-        {% assign collect_two = collections[settings.home_featured_collection_two] %}
-        <div class="p-card--highlighted">
-          <a href="{{ collect_two.url }}" class="row u-equal-height u-vertically-center">
-            <div class="col-2 col-small-1 col-medium-2">
-              <img src="{{ 'icon-collection-2.png' | asset_url }}" alt="{{ collect_two.title }}">
-            </div>
-            <div class="col-3 col-small-3 col-medium-3">
-              <h4>{{ collect_two.metafields.c_f['[c]Homepage title'] }}&nbsp;&rsaquo;</h4>
-              <h5>{{ collect_two.metafields.c_f['[c]Collection Price'] | money_without_trailing_zeros }} {{ settings.home_featured_pricing }}</h5>
-              {% unless settings.home_featured_collection_two_desc == blank or settings.home_featured_collection_two_desc.empty? %}
-              <h6>{{ settings.home_featured_collection_two_desc }}</h6>
-              {% endunless %}
-            </div>
-          </a>
-        </div>
-        {% endif %}
-
-        {% if settings.home_featured_collection_three %}
-        {% assign collect_three = collections[settings.home_featured_collection_three] %}
-        <div class="p-card--highlighted">
-          <a href="{{ collect_three.url }}" class="row u-equal-height u-vertically-center">
-            <div class="col-2 col-small-1 col-medium-2">
-              <img src="{{ 'icon-collection-3.png' | asset_url }}" alt="{{ collect_three.title }}">
-            </div>
-            <div class="col-3 col-small-3 col-medium-3">
-              <h4>{{ collect_three.metafields.c_f['[c]Homepage title'] }}&nbsp;&rsaquo;</h4>
-              <h5>{{ collect_three.metafields.c_f['[c]Collection Price'] | money_without_trailing_zeros }} {{ settings.home_featured_pricing }}</h5>
-              {% unless settings.home_featured_collection_three_desc == blank or settings.home_featured_collection_three_desc.empty? %}
-              <h6>{{ settings.home_featured_collection_three_desc }}</h6>
-              {% endunless %}
-            </div>
-          </a>
-        </div>
-        {% endif %}
-      </div>
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-7">
+      <h3>{{ settings.home_featured_heading }}</h3>
+      <p>{{ settings.home_featured_description }}</p>
+      {% unless settings.homepage_page == blank or pages[settings.homepage_page].empty? %}
+      {% assign page = pages[settings.homepage_page] %}
+        {{ page.content | replace: '<ul>', '<ul class="p-list">' | replace: '<li>**', '<li class="p-list__item is-ticked">' }}
+      {% endunless %}
     </div>
-  </section>
-
-
-  {% unless settings.home_includes_toggle == false %}
-    <section class="p-strip">
-      <div class="row">
-        <div class="col-8">
-          <h3>{{ settings.home_includes_heading }}</h3>
-
-          {{ settings.home_includes_copy | replace: '<ul>', '<ul class="p-list">' | replace: '<li>', '<li class="p-list__item is-ticked">' }}
-        </div>
+    <div class="col-5">
+      {% if settings.home_featured_collection_one %}
+      {% assign collect_one = collections[settings.home_featured_collection_one] %}
+      <div class="p-card--highlighted">
+        <a href="{{ collect_one.url }}" class="row u-equal-height u-vertically-center">
+          <div class="col-2 col-small-1 col-medium-2">
+            <img src="{{ 'icon-collection-1.png' | asset_url }}" alt="{{ collect_one.title }}">
+          </div>
+          <div class="col-3 col-small-3 col-medium-3">
+            <h4>{{ collect_one.metafields.c_f['[c]Homepage title'] }}&nbsp;&rsaquo;</h4>
+            <h5>{{ collect_one.metafields.c_f['[c]Collection Price'] | money_without_trailing_zeros }} {{ settings.home_featured_pricing }}</h5>
+            {% unless settings.home_featured_collection_one_desc == blank or settings.home_featured_collection_one_desc.empty? %}
+            <h6>{{ settings.home_featured_collection_one_desc }}</h6>
+            {% endunless %}
+          </div>
+        </a>
       </div>
-    </section>
-  {% endunless %}
+      {% endif %}
+
+      {% if settings.home_featured_collection_two %}
+      {% assign collect_two = collections[settings.home_featured_collection_two] %}
+      <div class="p-card--highlighted">
+        <a href="{{ collect_two.url }}" class="row u-equal-height u-vertically-center">
+          <div class="col-2 col-small-1 col-medium-2">
+            <img src="{{ 'icon-collection-2.png' | asset_url }}" alt="{{ collect_two.title }}">
+          </div>
+          <div class="col-3 col-small-3 col-medium-3">
+            <h4>{{ collect_two.metafields.c_f['[c]Homepage title'] }}&nbsp;&rsaquo;</h4>
+            <h5>{{ collect_two.metafields.c_f['[c]Collection Price'] | money_without_trailing_zeros }} {{ settings.home_featured_pricing }}</h5>
+            {% unless settings.home_featured_collection_two_desc == blank or settings.home_featured_collection_two_desc.empty? %}
+            <h6>{{ settings.home_featured_collection_two_desc }}</h6>
+            {% endunless %}
+          </div>
+        </a>
+      </div>
+      {% endif %}
+
+      {% if settings.home_featured_collection_three %}
+      {% assign collect_three = collections[settings.home_featured_collection_three] %}
+      <div class="p-card--highlighted">
+        <a href="{{ collect_three.url }}" class="row u-equal-height u-vertically-center">
+          <div class="col-2 col-small-1 col-medium-2">
+            <img src="{{ 'icon-collection-3.png' | asset_url }}" alt="{{ collect_three.title }}">
+          </div>
+          <div class="col-3 col-small-3 col-medium-3">
+            <h4>{{ collect_three.metafields.c_f['[c]Homepage title'] }}&nbsp;&rsaquo;</h4>
+            <h5>{{ collect_three.metafields.c_f['[c]Collection Price'] | money_without_trailing_zeros }} {{ settings.home_featured_pricing }}</h5>
+            {% unless settings.home_featured_collection_three_desc == blank or settings.home_featured_collection_three_desc.empty? %}
+            <h6>{{ settings.home_featured_collection_three_desc }}</h6>
+            {% endunless %}
+          </div>
+        </a>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+</section>
 
 
+{% unless settings.home_includes_toggle == false %}
   <section class="p-strip">
-    <div class="u-fixed-width">
-      <h2 class="p-muted-heading u-align--center" style="max-width: none;">{{ settings.home_customers_heading }}</h2>
-      <ul class="p-inline-images">
-        <li class="p-inline-images__item">
-        {% if settings.link_customer_one == true %}
-          <a href="{{ settings.link_customer_one_url | url_escape }}"><img src="{{ 'logo-bloomberg.png' | asset_url }}" alt="Bloomberg logo" /></a>
-        {% else %}
-          <img src="{{ 'logo-bloomberg.png' | asset_url }}"  alt="Bloomberg logo" />
-        {% endif %}
-        </li>
-
-        <li class="p-inline-images__item">
-        {% if settings.link_customer_two == true %}
-          <a href="{{ settings.link_customer_two_url | url_escape }}"><img src="{{ 'logo-att.png' | asset_url }}" alt="AT&T logo" /></a>
-        {% else %}
-          <img src="{{ 'logo-att.png' | asset_url }}" alt="AT&T logo" />
-        {% endif %}
-        </li>
-
-        <li class="p-inline-images__item">
-        {% if settings.link_customer_three == true %}
-          <a href="{{ settings.link_customer_three_url | url_escape }}"><img src="{{ 'logo-walmart.png' | asset_url }}" alt="Walmart logo" /></a>
-        {% else %}
-          <img src="{{ 'logo-walmart.png' | asset_url }}" alt="Walmart logo" />
-        {% endif %}
-        </li>
-
-        <li class="p-inline-images__item">
-        {% if settings.link_customer_four == true %}
-          <a href="{{ settings.link_customer_four_url | url_escape }}"><img src="{{ 'logo-tmobile.png' | asset_url }}" alt="T-Mobile logo" /></a>
-        {% else %}
-          <img src="{{ 'logo-tmobile.png' | asset_url }}" alt="T-Mobile logo" />
-        {% endif %}
-        </li>
-
-        <li class="p-inline-images__item">
-        {% if settings.link_customer_five == true %}
-          <a href="{{ settings.link_customer_five_url | url_escape }}"><img src="{{ 'logo-ebay.png' | asset_url }}" alt="Ebay logo" /></a>
-        {% else %}
-          <img src="{{ 'logo-ebay.png' | asset_url }}" alt="Ebay logo" />
-        {% endif %}
-        </li>
-
-        <li class="p-inline-images__item">
-        {% if settings.link_customer_six == true %}
-          <a href="{{ settings.link_customer_six_url | url_escape }}"><img src="{{ 'logo-cisco.png' | asset_url }}" alt="Cisco logo" /></a>
-        {% else %}
-          <img src="{{ 'logo-cisco.png' | asset_url }}" alt="Cisco logo" />
-        {% endif %}
-        </li>
-
-        <li class="p-inline-images__item">
-        {% if settings.link_customer_seven == true %}
-          <a href="{{ settings.link_customer_seven_url | url_escape }}"><img src="{{ 'logo-ntt.png' | asset_url }}" alt="NTT logo" /></a>
-        {% else %}
-          <img src="{{ 'logo-ntt.png' | asset_url }}" alt="NTT logo" />
-        {% endif %}
-        </li>
-
-        <li class="p-inline-images__item">
-        {% if settings.link_customer_eight == true %}
-          <a href="{{ settings.link_customer_eight_url | url_escape }}"><img src="{{ 'logo-bestbuy.png' | asset_url }}" alt="Best Buy logo" /></a>
-        {% else %}
-          <img src="{{ 'logo-bestbuy.png' | asset_url }}" alt="Best Buy logo" />
-        {% endif %}
-        </li>
-
-      </ul>
-    </div>
-  </section>
-
-
-  <section class="p-strip--dark" style="background-color: #2c001e;">
-    <div class="row u-vertically-center">
+    <div class="row">
       <div class="col-8">
-        <h2>{{ settings.home_canonical_heading }}{% if settings.home_canonical_heading_img == true %} <img src="{{ 'canonical-logo.png' | asset_url }}" alt="Canonical">{% endif %}</h2>
-        <p>{{ settings.home_canonical_description }}</p>
-        <p><a href="{{ settings.home_canonical_link | url_param_escape }}" class="p-link--external p-link--inverted">{{ settings.home_canonical_link_text }}</a></p>
-      </div>
+        <h3>{{ settings.home_includes_heading }}</h3>
 
-      <div class="col-4">
-        <img src="{{ 'canonical-image.png' | asset_url }}" alt="Canonical image">
+        {{ settings.home_includes_copy | replace: '<ul>', '<ul class="p-list">' | replace: '<li>', '<li class="p-list__item is-ticked">' }}
       </div>
     </div>
   </section>
-</div>
+{% endunless %}
+
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="p-muted-heading u-align--center" style="max-width: none;">{{ settings.home_customers_heading }}</h2>
+    <ul class="p-inline-images">
+      <li class="p-inline-images__item">
+      {% if settings.link_customer_one == true %}
+        <a href="{{ settings.link_customer_one_url | url_escape }}"><img src="{{ 'logo-bloomberg.png' | asset_url }}" alt="Bloomberg logo" /></a>
+      {% else %}
+        <img src="{{ 'logo-bloomberg.png' | asset_url }}"  alt="Bloomberg logo" />
+      {% endif %}
+      </li>
+
+      <li class="p-inline-images__item">
+      {% if settings.link_customer_two == true %}
+        <a href="{{ settings.link_customer_two_url | url_escape }}"><img src="{{ 'logo-att.png' | asset_url }}" alt="AT&T logo" /></a>
+      {% else %}
+        <img src="{{ 'logo-att.png' | asset_url }}" alt="AT&T logo" />
+      {% endif %}
+      </li>
+
+      <li class="p-inline-images__item">
+      {% if settings.link_customer_three == true %}
+        <a href="{{ settings.link_customer_three_url | url_escape }}"><img src="{{ 'logo-walmart.png' | asset_url }}" alt="Walmart logo" /></a>
+      {% else %}
+        <img src="{{ 'logo-walmart.png' | asset_url }}" alt="Walmart logo" />
+      {% endif %}
+      </li>
+
+      <li class="p-inline-images__item">
+      {% if settings.link_customer_four == true %}
+        <a href="{{ settings.link_customer_four_url | url_escape }}"><img src="{{ 'logo-tmobile.png' | asset_url }}" alt="T-Mobile logo" /></a>
+      {% else %}
+        <img src="{{ 'logo-tmobile.png' | asset_url }}" alt="T-Mobile logo" />
+      {% endif %}
+      </li>
+
+      <li class="p-inline-images__item">
+      {% if settings.link_customer_five == true %}
+        <a href="{{ settings.link_customer_five_url | url_escape }}"><img src="{{ 'logo-ebay.png' | asset_url }}" alt="Ebay logo" /></a>
+      {% else %}
+        <img src="{{ 'logo-ebay.png' | asset_url }}" alt="Ebay logo" />
+      {% endif %}
+      </li>
+
+      <li class="p-inline-images__item">
+      {% if settings.link_customer_six == true %}
+        <a href="{{ settings.link_customer_six_url | url_escape }}"><img src="{{ 'logo-cisco.png' | asset_url }}" alt="Cisco logo" /></a>
+      {% else %}
+        <img src="{{ 'logo-cisco.png' | asset_url }}" alt="Cisco logo" />
+      {% endif %}
+      </li>
+
+      <li class="p-inline-images__item">
+      {% if settings.link_customer_seven == true %}
+        <a href="{{ settings.link_customer_seven_url | url_escape }}"><img src="{{ 'logo-ntt.png' | asset_url }}" alt="NTT logo" /></a>
+      {% else %}
+        <img src="{{ 'logo-ntt.png' | asset_url }}" alt="NTT logo" />
+      {% endif %}
+      </li>
+
+      <li class="p-inline-images__item">
+      {% if settings.link_customer_eight == true %}
+        <a href="{{ settings.link_customer_eight_url | url_escape }}"><img src="{{ 'logo-bestbuy.png' | asset_url }}" alt="Best Buy logo" /></a>
+      {% else %}
+        <img src="{{ 'logo-bestbuy.png' | asset_url }}" alt="Best Buy logo" />
+      {% endif %}
+      </li>
+
+    </ul>
+  </div>
+</section>
+
+
+<section class="p-strip--dark" style="background-color: #2c001e;">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      <h2>{{ settings.home_canonical_heading }}{% if settings.home_canonical_heading_img == true %} <img src="{{ 'canonical-logo.png' | asset_url }}" alt="Canonical">{% endif %}</h2>
+      <p>{{ settings.home_canonical_description }}</p>
+      <p><a href="{{ settings.home_canonical_link | url_param_escape }}" class="p-link--external p-link--inverted">{{ settings.home_canonical_link_text }}</a></p>
+    </div>
+
+    <div class="col-4">
+      <img src="{{ 'canonical-image.png' | asset_url }}" alt="Canonical image">
+    </div>
+  </div>
+</section>

--- a/src/templates/product.liquid
+++ b/src/templates/product.liquid
@@ -3,114 +3,110 @@
 	window.location.replace("{{ shop.url }}");
 </script>
 
-{% include 'site-nav' %}
+{% assign add_to_cart = 'Add to cart' %}
+{% assign sold_out = 'Sold Out' %}
+{% assign unavailable = 'Unavailable' %}
 
-<div id="main-content" class="main" role="main">
-	{% assign add_to_cart = 'Add to cart' %}
-	{% assign sold_out = 'Sold Out' %}
-	{% assign unavailable = 'Unavailable' %}
+<section itemscope itemtype="http://schema.org/Product">
+	<meta itemprop="url" content="{{ shop.url }}{{ product.url }}" />
+	<meta itemprop="image" content="{{ product | img_url: 'grande' }}" />
 
-	<section itemscope itemtype="http://schema.org/Product">
-		<meta itemprop="url" content="{{ shop.url }}{{ product.url }}" />
-		<meta itemprop="image" content="{{ product | img_url: 'grande' }}" />
+	<form action="/cart/add" data-productid="{{product.id}}"  method="post" enctype="multipart/form-data"> 
+		<div class="p-strip--light">
+			<div class="row u-vertically-center">
+				<div class="col-7">
+					<h1 itemprop="name">{{ product.title }}</h1>
 
-		<form action="/cart/add" data-productid="{{product.id}}"  method="post" enctype="multipart/form-data"> 
-			<div class="p-strip--light">
-				<div class="row u-vertically-center">
-					<div class="col-7">
-						<h1 itemprop="name">{{ product.title }}</h1>
+					{% assign product_vendor_handle = product.vendor | handle %}
 
-						{% assign product_vendor_handle = product.vendor | handle %}
+					{% if collections[product_vendor_handle].handle == product_vendor_handle %}
+						{% assign vendor_url = collections[product_vendor_handle].url %}
+					{% else %}
+						{% assign vendor_url = product.vendor | url_for_vendor %}
+					{% endif %}
+					<h2 itemprop="brand" class="delta">{{ product.vendor | link_to: vendor_url }}</h2>
+				</div>
 
-						{% if collections[product_vendor_handle].handle == product_vendor_handle %}
-							{% assign vendor_url = collections[product_vendor_handle].url %}
-						{% else %}
-							{% assign vendor_url = product.vendor | url_for_vendor %}
-						{% endif %}
-						<h2 itemprop="brand" class="delta">{{ product.vendor | link_to: vendor_url }}</h2>
-					</div>
-
-					<div class="col-5 u-align--right">
-						{% if product.images.size == 0 %}
-							<img src="{{ '' | img_url: 'grande' }}" alt="" />
-						{% else %}
-							{% assign featured_image = product.selected_or_first_available_variant.featured_image | default: product.featured_image %}
-							<img src="{{ featured_image | img_url: 'grande' }}" alt="{{ product.title | escape }}" />
-						{% endif %}
-					</div>
+				<div class="col-5 u-align--right">
+					{% if product.images.size == 0 %}
+						<img src="{{ '' | img_url: 'grande' }}" alt="" />
+					{% else %}
+						{% assign featured_image = product.selected_or_first_available_variant.featured_image | default: product.featured_image %}
+						<img src="{{ featured_image | img_url: 'grande' }}" alt="{{ product.title | escape }}" />
+					{% endif %}
 				</div>
 			</div>
+		</div>
 
-			<div class="p-strip is-bordered">
-				<div class="row">
-					<div class="col-12">
-						<div id="product-description" class="rte" itemprop="description">
-							{{ product.description }}
-						</div>
+		<div class="p-strip is-bordered">
+			<div class="row">
+				<div class="col-12">
+					<div id="product-description" class="rte" itemprop="description">
+						{{ product.description }}
+					</div>
 
-						<div id="shopify-product-reviews" data-id="{{ product.id }}">{{ product.metafields.spr.reviews }}</div>
+					<div id="shopify-product-reviews" data-id="{{ product.id }}">{{ product.metafields.spr.reviews }}</div>
 
-						<div id="product-price" itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="delta">
-							<meta itemprop="priceCurrency" content="{{ shop.currency }}" />
-							{% if product.available %}
-							<link itemprop="availability" href="http://schema.org/InStock" />
+					<div id="product-price" itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="delta">
+						<meta itemprop="priceCurrency" content="{{ shop.currency }}" />
+						{% if product.available %}
+						<link itemprop="availability" href="http://schema.org/InStock" />
+						{% else %}
+						<link itemprop="availability" href="http://schema.org/OutOfStock" />
+						{% endif %}
+						<p>
+							{% assign variant = product.selected_or_first_available_variant %}
+							{% if product.compare_at_price > product.price %}
+							<span class="product-price on-sale" itemprop="price">{{ variant.price | money }}</span>
+							<s class="product-compare-price">{{ variant.compare_at_price | money }}</s>
 							{% else %}
-							<link itemprop="availability" href="http://schema.org/OutOfStock" />
+							<span class="product-price" itemprop="price">{{ variant.price | money }}</span>
 							{% endif %}
-							<p>
-								{% assign variant = product.selected_or_first_available_variant %}
-								{% if product.compare_at_price > product.price %}
-								<span class="product-price on-sale" itemprop="price">{{ variant.price | money }}</span>
-								<s class="product-compare-price">{{ variant.compare_at_price | money }}</s>
-								{% else %}
-								<span class="product-price" itemprop="price">{{ variant.price | money }}</span>
-								{% endif %}
-							</p>
-						</div>
-
-						{% assign hide_default_title = false %}
-						{% if product.variants.size == 1 and product.variants.first.title contains 'Default' %}
-							{% assign hide_default_title = true %}
-						{% endif %}
-
-						<div id="product-variants" class="{% if hide_default_title %} hidden{% endif %}">
-							<select id="product-select" name="id" data-productid="{{product.id}}"> 
-							{% for variant in product.variants %}
-								<option{% if variant == product.selected_or_first_available_variant %} selected{% endif %} value="{{ variant.id }}">
-								{{ variant.title }} - {{ variant.price | money }}
-								</option>
-							{% endfor %}
-							</select>
-						</div>
-
-						<div id="backorder" class="hidden">
-							<p>{{ '%s is back-ordered. We will ship it separately in 10 to 15 days.' | replace: '%s', '<span id="selected-variant"></span>' }}</p>
-						</div>
-
-						<div id="product-add">
-							<input type="submit" name="add" id="add" class="primary button" value="{{ add_to_cart | escape }}">
-						</div>
-
-						{% if collection %}
-							{% if collection.previous_product or collection.next_product %}
-							<div>
-							{% if collection.previous_product %}
-								{% capture prev_url %}{{ collection.previous_product}}#content{% endcapture %}
-								<span class="left">{{ '&larr; Previous Product' | link_to: prev_url }}</span>
-							{% endif %}
-							{% if collection.next_product %}
-								{% capture next_url %}{{ collection.next_product}}#content{% endcapture %}
-								<span class="right">{{ 'Next Product &rarr;' | link_to: next_url }}</span>
-							{% endif %}
-							</div>
-							{% endif %}
-						{% endif %}
+						</p>
 					</div>
+
+					{% assign hide_default_title = false %}
+					{% if product.variants.size == 1 and product.variants.first.title contains 'Default' %}
+						{% assign hide_default_title = true %}
+					{% endif %}
+
+					<div id="product-variants" class="{% if hide_default_title %} hidden{% endif %}">
+						<select id="product-select" name="id" data-productid="{{product.id}}"> 
+						{% for variant in product.variants %}
+							<option{% if variant == product.selected_or_first_available_variant %} selected{% endif %} value="{{ variant.id }}">
+							{{ variant.title }} - {{ variant.price | money }}
+							</option>
+						{% endfor %}
+						</select>
+					</div>
+
+					<div id="backorder" class="hidden">
+						<p>{{ '%s is back-ordered. We will ship it separately in 10 to 15 days.' | replace: '%s', '<span id="selected-variant"></span>' }}</p>
+					</div>
+
+					<div id="product-add">
+						<input type="submit" name="add" id="add" class="primary button" value="{{ add_to_cart | escape }}">
+					</div>
+
+					{% if collection %}
+						{% if collection.previous_product or collection.next_product %}
+						<div>
+						{% if collection.previous_product %}
+							{% capture prev_url %}{{ collection.previous_product}}#content{% endcapture %}
+							<span class="left">{{ '&larr; Previous Product' | link_to: prev_url }}</span>
+						{% endif %}
+						{% if collection.next_product %}
+							{% capture next_url %}{{ collection.next_product}}#content{% endcapture %}
+							<span class="right">{{ 'Next Product &rarr;' | link_to: next_url }}</span>
+						{% endif %}
+						</div>
+						{% endif %}
+					{% endif %}
 				</div>
 			</div>
-		</form>
-	</section>
-</div>
+		</div>
+	</form>
+</section>
 
 <script>
 

--- a/src/templates/product.liquid
+++ b/src/templates/product.liquid
@@ -1,145 +1,116 @@
+{% comment %}Remove this script tag to reinstate individual product pages{% endcomment %}
 <script>
 	window.location.replace("{{ shop.url }}");
 </script>
 
-{% assign add_to_cart = 'Add to cart' %}
-{% assign sold_out = 'Sold Out' %}
-{% assign unavailable = 'Unavailable' %}
+{% include 'site-nav' %}
 
-<div class="product" itemscope itemtype="http://schema.org/Product">
+<div id="main-content" class="main" role="main">
+	{% assign add_to_cart = 'Add to cart' %}
+	{% assign sold_out = 'Sold Out' %}
+	{% assign unavailable = 'Unavailable' %}
 
-	<meta itemprop="url" content="{{ shop.url }}{{ product.url }}" />
-	<meta itemprop="image" content="{{ product | img_url: 'grande' }}" />
+	<section itemscope itemtype="http://schema.org/Product">
+		<meta itemprop="url" content="{{ shop.url }}{{ product.url }}" />
+		<meta itemprop="image" content="{{ product | img_url: 'grande' }}" />
 
-	<form action="/cart/add" data-productid="{{product.id}}"  method="post" enctype="multipart/form-data"> 
- {% if product.available %}{% comment %}{% include 'subscription-product' %}{% endcomment %}{% endif %} 
+		<form action="/cart/add" data-productid="{{product.id}}"  method="post" enctype="multipart/form-data"> 
+			<div class="p-strip--light">
+				<div class="row u-vertically-center">
+					<div class="col-7">
+						<h1 itemprop="name">{{ product.title }}</h1>
 
-		<div class="product-photos">
+						{% assign product_vendor_handle = product.vendor | handle %}
 
-		{% if product.images.size == 0 %}
+						{% if collections[product_vendor_handle].handle == product_vendor_handle %}
+							{% assign vendor_url = collections[product_vendor_handle].url %}
+						{% else %}
+							{% assign vendor_url = product.vendor | url_for_vendor %}
+						{% endif %}
+						<h2 itemprop="brand" class="delta">{{ product.vendor | link_to: vendor_url }}</h2>
+					</div>
 
-			<div class="product-photo-container">
-				<img src="{{ '' | img_url: 'grande' }}" alt="" />
-			</div>
-
-		{% else %}
-
-			{% assign featured_image = product.selected_or_first_available_variant.featured_image | default: product.featured_image %}
-			<div class="product-photo-container">
-				<a href="{{ featured_image | img_url: '1024x1024' }}">
-					<img src="{{ featured_image | img_url: 'grande' }}" alt="{{ product.title | escape }}" />
-				</a>
-			</div>
-
-			{% if product.images.size > 1 %}
-			<ul class="product-photo-thumbs clearfix grid">
-				{% for image in product.images %}
-				<li class="product-photo-thumb two-per-row">
-					<a href="{{ image | img_url: '1024x1024' }}">
-						<img src="{{ image | img_url: 'large' }}" alt="{{ image.alt | escape }}" />
-					</a>
-				</li>
-				{% endfor %}
-			</ul>
-			{% endif %}
-
-		{% endif %}
-
-		</div><!-- .product-photos -->
-
-		<div class="product-details">
-
-			<h1 itemprop="name">{{ product.title }}</h1>
-
-			{% assign product_vendor_handle = product.vendor | handle %}
-			{% comment %}
-			Do we have a collection that has the same name as our product vendor name?
-			If we do, let's have the vendor link point to it.
-			If not, we will point to the automatic vendor collection.
-			{% endcomment %}
-			{% if collections[product_vendor_handle].handle == product_vendor_handle %}
-				{% assign vendor_url = collections[product_vendor_handle].url %}
-			{% else %}
-				{% assign vendor_url = product.vendor | url_for_vendor %}
-			{% endif %}
-			<h2 itemprop="brand" class="delta">{{ product.vendor | link_to: vendor_url }}</h2>
-
-			<div id="product-description" class="rte" itemprop="description">
-				{{ product.description }}
-			</div>
-
-			{% comment %}
-				All themes by Shopify should support the Product Reviews app out of the box.
-				https://apps.shopify.com/product-reviews
-			{% endcomment %}
-			<div id="shopify-product-reviews" data-id="{{ product.id }}">{{ product.metafields.spr.reviews }}</div>
-
-			<div id="product-price" itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="delta">
-				<meta itemprop="priceCurrency" content="{{ shop.currency }}" />
-				{% if product.available %}
-				<link itemprop="availability" href="http://schema.org/InStock" />
-				{% else %}
-				<link itemprop="availability" href="http://schema.org/OutOfStock" />
-				{% endif %}
-				<p>
-					{% assign variant = product.selected_or_first_available_variant %}
-					{% if product.compare_at_price > product.price %}
-					<span class="product-price on-sale" itemprop="price">{{ variant.price | money }}</span>
-					<s class="product-compare-price">{{ variant.compare_at_price | money }}</s>
-					{% else %}
-					<span class="product-price" itemprop="price">{{ variant.price | money }}</span>
-					{% endif %}
-				</p>
-			</div>
-
-			{% assign hide_default_title = false %}
-			{% if product.variants.size == 1 and product.variants.first.title contains 'Default' %}
-				{% assign hide_default_title = true %}
-			{% endif %}
-
-			<div id="product-variants" class="{% if hide_default_title %} hidden{% endif %}">
-				<select id="product-select" name="id" data-productid="{{product.id}}"> 
-				{% for variant in product.variants %}
-					<option{% if variant == product.selected_or_first_available_variant %} selected{% endif %} value="{{ variant.id }}">
-					{{ variant.title }} - {{ variant.price | money }}
-					</option>
-				{% endfor %}
-				</select>
-			</div>
-
-			<div id="backorder" class="hidden">
-				<p>{{ '%s is back-ordered. We will ship it separately in 10 to 15 days.' | replace: '%s', '<span id="selected-variant"></span>' }}</p>
-			</div>
-
-			<div id="product-add">
-				<input type="submit" name="add" id="add" class="primary button" value="{{ add_to_cart | escape }}">
-			</div>
-
-			{% if collection %}
-				{% if collection.previous_product or collection.next_product %}
-				<div>
-				{% if collection.previous_product %}
-					{% capture prev_url %}{{ collection.previous_product}}#content{% endcapture %}
-					<span class="left">{{ '&larr; Previous Product' | link_to: prev_url }}</span>
-				{% endif %}
-				{% if collection.next_product %}
-					{% capture next_url %}{{ collection.next_product}}#content{% endcapture %}
-					<span class="right">{{ 'Next Product &rarr;' | link_to: next_url }}</span>
-				{% endif %}
+					<div class="col-5 u-align--right">
+						{% if product.images.size == 0 %}
+							<img src="{{ '' | img_url: 'grande' }}" alt="" />
+						{% else %}
+							{% assign featured_image = product.selected_or_first_available_variant.featured_image | default: product.featured_image %}
+							<img src="{{ featured_image | img_url: 'grande' }}" alt="{{ product.title | escape }}" />
+						{% endif %}
+					</div>
 				</div>
-				{% endif %}
-			{% endif %}
+			</div>
 
-		</div><!-- .product-details -->
+			<div class="p-strip is-bordered">
+				<div class="row">
+					<div class="col-12">
+						<div id="product-description" class="rte" itemprop="description">
+							{{ product.description }}
+						</div>
 
-	</form>
+						<div id="shopify-product-reviews" data-id="{{ product.id }}">{{ product.metafields.spr.reviews }}</div>
 
+						<div id="product-price" itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="delta">
+							<meta itemprop="priceCurrency" content="{{ shop.currency }}" />
+							{% if product.available %}
+							<link itemprop="availability" href="http://schema.org/InStock" />
+							{% else %}
+							<link itemprop="availability" href="http://schema.org/OutOfStock" />
+							{% endif %}
+							<p>
+								{% assign variant = product.selected_or_first_available_variant %}
+								{% if product.compare_at_price > product.price %}
+								<span class="product-price on-sale" itemprop="price">{{ variant.price | money }}</span>
+								<s class="product-compare-price">{{ variant.compare_at_price | money }}</s>
+								{% else %}
+								<span class="product-price" itemprop="price">{{ variant.price | money }}</span>
+								{% endif %}
+							</p>
+						</div>
+
+						{% assign hide_default_title = false %}
+						{% if product.variants.size == 1 and product.variants.first.title contains 'Default' %}
+							{% assign hide_default_title = true %}
+						{% endif %}
+
+						<div id="product-variants" class="{% if hide_default_title %} hidden{% endif %}">
+							<select id="product-select" name="id" data-productid="{{product.id}}"> 
+							{% for variant in product.variants %}
+								<option{% if variant == product.selected_or_first_available_variant %} selected{% endif %} value="{{ variant.id }}">
+								{{ variant.title }} - {{ variant.price | money }}
+								</option>
+							{% endfor %}
+							</select>
+						</div>
+
+						<div id="backorder" class="hidden">
+							<p>{{ '%s is back-ordered. We will ship it separately in 10 to 15 days.' | replace: '%s', '<span id="selected-variant"></span>' }}</p>
+						</div>
+
+						<div id="product-add">
+							<input type="submit" name="add" id="add" class="primary button" value="{{ add_to_cart | escape }}">
+						</div>
+
+						{% if collection %}
+							{% if collection.previous_product or collection.next_product %}
+							<div>
+							{% if collection.previous_product %}
+								{% capture prev_url %}{{ collection.previous_product}}#content{% endcapture %}
+								<span class="left">{{ '&larr; Previous Product' | link_to: prev_url }}</span>
+							{% endif %}
+							{% if collection.next_product %}
+								{% capture next_url %}{{ collection.next_product}}#content{% endcapture %}
+								<span class="right">{{ 'Next Product &rarr;' | link_to: next_url }}</span>
+							{% endif %}
+							</div>
+							{% endif %}
+						{% endif %}
+					</div>
+				</div>
+			</div>
+		</form>
+	</section>
 </div>
-
-{% comment %}
-	Adding support for product options. See here for details:
-	http://docs.shopify.com/support/your-website/themes/can-i-make-my-theme-use-products-with-multiple-options
-{% endcomment %}
 
 <script>
 

--- a/src/templates/product.liquid
+++ b/src/templates/product.liquid
@@ -1,6 +1,6 @@
 {% comment %}Remove this script tag to reinstate individual product pages{% endcomment %}
 <script>
-	window.location.replace("{{ shop.url }}");
+  window.location.replace("{{ shop.url }}");
 </script>
 
 {% assign add_to_cart = 'Add to cart' %}
@@ -8,163 +8,163 @@
 {% assign unavailable = 'Unavailable' %}
 
 <section itemscope itemtype="http://schema.org/Product">
-	<meta itemprop="url" content="{{ shop.url }}{{ product.url }}" />
-	<meta itemprop="image" content="{{ product | img_url: 'grande' }}" />
+  <meta itemprop="url" content="{{ shop.url }}{{ product.url }}" />
+  <meta itemprop="image" content="{{ product | img_url: 'grande' }}" />
 
-	<form action="/cart/add" data-productid="{{product.id}}"  method="post" enctype="multipart/form-data"> 
-		<div class="p-strip--light">
-			<div class="row u-vertically-center">
-				<div class="col-7">
-					<h1 itemprop="name">{{ product.title }}</h1>
+  <form action="/cart/add" data-productid="{{product.id}}"  method="post" enctype="multipart/form-data"> 
+    <div class="p-strip--light">
+      <div class="row u-vertically-center">
+        <div class="col-7">
+          <h1 itemprop="name">{{ product.title }}</h1>
 
-					{% assign product_vendor_handle = product.vendor | handle %}
+          {% assign product_vendor_handle = product.vendor | handle %}
 
-					{% if collections[product_vendor_handle].handle == product_vendor_handle %}
-						{% assign vendor_url = collections[product_vendor_handle].url %}
-					{% else %}
-						{% assign vendor_url = product.vendor | url_for_vendor %}
-					{% endif %}
-					<h2 itemprop="brand" class="delta">{{ product.vendor | link_to: vendor_url }}</h2>
-				</div>
+          {% if collections[product_vendor_handle].handle == product_vendor_handle %}
+            {% assign vendor_url = collections[product_vendor_handle].url %}
+          {% else %}
+            {% assign vendor_url = product.vendor | url_for_vendor %}
+          {% endif %}
+          <h2 itemprop="brand" class="delta">{{ product.vendor | link_to: vendor_url }}</h2>
+        </div>
 
-				<div class="col-5 u-align--right">
-					{% if product.images.size == 0 %}
-						<img src="{{ '' | img_url: 'grande' }}" alt="" />
-					{% else %}
-						{% assign featured_image = product.selected_or_first_available_variant.featured_image | default: product.featured_image %}
-						<img src="{{ featured_image | img_url: 'grande' }}" alt="{{ product.title | escape }}" />
-					{% endif %}
-				</div>
-			</div>
-		</div>
+        <div class="col-5 u-align--right">
+          {% if product.images.size == 0 %}
+            <img src="{{ '' | img_url: 'grande' }}" alt="" />
+          {% else %}
+            {% assign featured_image = product.selected_or_first_available_variant.featured_image | default: product.featured_image %}
+            <img src="{{ featured_image | img_url: 'grande' }}" alt="{{ product.title | escape }}" />
+          {% endif %}
+        </div>
+      </div>
+    </div>
 
-		<div class="p-strip is-bordered">
-			<div class="row">
-				<div class="col-12">
-					<div id="product-description" class="rte" itemprop="description">
-						{{ product.description }}
-					</div>
+    <div class="p-strip is-bordered">
+      <div class="row">
+        <div class="col-12">
+          <div id="product-description" class="rte" itemprop="description">
+            {{ product.description }}
+          </div>
 
-					<div id="shopify-product-reviews" data-id="{{ product.id }}">{{ product.metafields.spr.reviews }}</div>
+          <div id="shopify-product-reviews" data-id="{{ product.id }}">{{ product.metafields.spr.reviews }}</div>
 
-					<div id="product-price" itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="delta">
-						<meta itemprop="priceCurrency" content="{{ shop.currency }}" />
-						{% if product.available %}
-						<link itemprop="availability" href="http://schema.org/InStock" />
-						{% else %}
-						<link itemprop="availability" href="http://schema.org/OutOfStock" />
-						{% endif %}
-						<p>
-							{% assign variant = product.selected_or_first_available_variant %}
-							{% if product.compare_at_price > product.price %}
-							<span class="product-price on-sale" itemprop="price">{{ variant.price | money }}</span>
-							<s class="product-compare-price">{{ variant.compare_at_price | money }}</s>
-							{% else %}
-							<span class="product-price" itemprop="price">{{ variant.price | money }}</span>
-							{% endif %}
-						</p>
-					</div>
+          <div id="product-price" itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="delta">
+            <meta itemprop="priceCurrency" content="{{ shop.currency }}" />
+            {% if product.available %}
+            <link itemprop="availability" href="http://schema.org/InStock" />
+            {% else %}
+            <link itemprop="availability" href="http://schema.org/OutOfStock" />
+            {% endif %}
+            <p>
+              {% assign variant = product.selected_or_first_available_variant %}
+              {% if product.compare_at_price > product.price %}
+              <span class="product-price on-sale" itemprop="price">{{ variant.price | money }}</span>
+              <s class="product-compare-price">{{ variant.compare_at_price | money }}</s>
+              {% else %}
+              <span class="product-price" itemprop="price">{{ variant.price | money }}</span>
+              {% endif %}
+            </p>
+          </div>
 
-					{% assign hide_default_title = false %}
-					{% if product.variants.size == 1 and product.variants.first.title contains 'Default' %}
-						{% assign hide_default_title = true %}
-					{% endif %}
+          {% assign hide_default_title = false %}
+          {% if product.variants.size == 1 and product.variants.first.title contains 'Default' %}
+            {% assign hide_default_title = true %}
+          {% endif %}
 
-					<div id="product-variants" class="{% if hide_default_title %} hidden{% endif %}">
-						<select id="product-select" name="id" data-productid="{{product.id}}"> 
-						{% for variant in product.variants %}
-							<option{% if variant == product.selected_or_first_available_variant %} selected{% endif %} value="{{ variant.id }}">
-							{{ variant.title }} - {{ variant.price | money }}
-							</option>
-						{% endfor %}
-						</select>
-					</div>
+          <div id="product-variants" class="{% if hide_default_title %} hidden{% endif %}">
+            <select id="product-select" name="id" data-productid="{{product.id}}"> 
+            {% for variant in product.variants %}
+              <option{% if variant == product.selected_or_first_available_variant %} selected{% endif %} value="{{ variant.id }}">
+              {{ variant.title }} - {{ variant.price | money }}
+              </option>
+            {% endfor %}
+            </select>
+          </div>
 
-					<div id="backorder" class="hidden">
-						<p>{{ '%s is back-ordered. We will ship it separately in 10 to 15 days.' | replace: '%s', '<span id="selected-variant"></span>' }}</p>
-					</div>
+          <div id="backorder" class="hidden">
+            <p>{{ '%s is back-ordered. We will ship it separately in 10 to 15 days.' | replace: '%s', '<span id="selected-variant"></span>' }}</p>
+          </div>
 
-					<div id="product-add">
-						<input type="submit" name="add" id="add" class="primary button" value="{{ add_to_cart | escape }}">
-					</div>
+          <div id="product-add">
+            <input type="submit" name="add" id="add" class="primary button" value="{{ add_to_cart | escape }}">
+          </div>
 
-					{% if collection %}
-						{% if collection.previous_product or collection.next_product %}
-						<div>
-						{% if collection.previous_product %}
-							{% capture prev_url %}{{ collection.previous_product}}#content{% endcapture %}
-							<span class="left">{{ '&larr; Previous Product' | link_to: prev_url }}</span>
-						{% endif %}
-						{% if collection.next_product %}
-							{% capture next_url %}{{ collection.next_product}}#content{% endcapture %}
-							<span class="right">{{ 'Next Product &rarr;' | link_to: next_url }}</span>
-						{% endif %}
-						</div>
-						{% endif %}
-					{% endif %}
-				</div>
-			</div>
-		</div>
-	</form>
+          {% if collection %}
+            {% if collection.previous_product or collection.next_product %}
+            <div>
+            {% if collection.previous_product %}
+              {% capture prev_url %}{{ collection.previous_product}}#content{% endcapture %}
+              <span class="left">{{ '&larr; Previous Product' | link_to: prev_url }}</span>
+            {% endif %}
+            {% if collection.next_product %}
+              {% capture next_url %}{{ collection.next_product}}#content{% endcapture %}
+              <span class="right">{{ 'Next Product &rarr;' | link_to: next_url }}</span>
+            {% endif %}
+            </div>
+            {% endif %}
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </form>
 </section>
 
 <script>
 
 var selectCallback = function(variant, selector) {
 
-	if (variant) {
+  if (variant) {
 
-		// Swap image.
-		if (variant.featured_image) {
-			var newImage = variant.featured_image; // New image object.
-			var mainImageDomEl = jQuery('.product-photo-container img')[0]; // DOM element of main image we need to swap.
-			Shopify.Image.switchImage(newImage, mainImageDomEl, switchImage); // Define switchImage (the callback) in your theme's JavaScript file.
-		}
+    // Swap image.
+    if (variant.featured_image) {
+      var newImage = variant.featured_image; // New image object.
+      var mainImageDomEl = jQuery('.product-photo-container img')[0]; // DOM element of main image we need to swap.
+      Shopify.Image.switchImage(newImage, mainImageDomEl, switchImage); // Define switchImage (the callback) in your theme's JavaScript file.
+    }
 
-		// Selected a valid variant that is available.
-		if (variant.available) {
+    // Selected a valid variant that is available.
+    if (variant.available) {
 
-			// Enabling add to cart button.
-			jQuery('#add').removeClass('disabled').prop('disabled', false).val({{ add_to_cart | json }});
+      // Enabling add to cart button.
+      jQuery('#add').removeClass('disabled').prop('disabled', false).val({{ add_to_cart | json }});
 
-			// If item is backordered yet can still be ordered, we'll show special message.
-			if (variant.inventory_management && variant.inventory_quantity <= 0) {
-				jQuery('#selected-variant').html({{ product.title | json }}{% unless hide_default_title %} + ' - ' + variant.title{% endunless %});
-				jQuery('#backorder').removeClass("hidden");
-			} else {
-				jQuery('#backorder').addClass("hidden");
-			}
+      // If item is backordered yet can still be ordered, we'll show special message.
+      if (variant.inventory_management && variant.inventory_quantity <= 0) {
+        jQuery('#selected-variant').html({{ product.title | json }}{% unless hide_default_title %} + ' - ' + variant.title{% endunless %});
+        jQuery('#backorder').removeClass("hidden");
+      } else {
+        jQuery('#backorder').addClass("hidden");
+      }
 
-		} else {
-			// Variant is sold out.
-			jQuery('#backorder').addClass('hidden');
-			jQuery('#add').val({{ sold_out | json }}).addClass('disabled').prop('disabled', true);
-		}
+    } else {
+      // Variant is sold out.
+      jQuery('#backorder').addClass('hidden');
+      jQuery('#add').val({{ sold_out | json }}).addClass('disabled').prop('disabled', true);
+    }
 
-		// Whether the variant is in stock or not, we can update the price and compare at price.
-		if ( variant.compare_at_price > variant.price ) {
-			jQuery('#product-price').html('<span class="product-price on-sale">'+ Shopify.formatMoney(variant.price, "{{ shop.money_format }}") +'</span>'+'&nbsp;<s class="product-compare-price">'+Shopify.formatMoney(variant.compare_at_price, "{{ shop.money_format }}")+ '</s>');
-		} else {
-			jQuery('#product-price').html('<span class="product-price">'+ Shopify.formatMoney(variant.price, "{{ shop.money_format }}") + '</span>' );
-		}
+    // Whether the variant is in stock or not, we can update the price and compare at price.
+    if ( variant.compare_at_price > variant.price ) {
+      jQuery('#product-price').html('<span class="product-price on-sale">'+ Shopify.formatMoney(variant.price, "{{ shop.money_format }}") +'</span>'+'&nbsp;<s class="product-compare-price">'+Shopify.formatMoney(variant.compare_at_price, "{{ shop.money_format }}")+ '</s>');
+    } else {
+      jQuery('#product-price').html('<span class="product-price">'+ Shopify.formatMoney(variant.price, "{{ shop.money_format }}") + '</span>' );
+    }
 
-	} else {
-		// variant doesn't exist.
-		jQuery('#product-price').empty();
-		jQuery('#backorder').addClass('hidden');
-		jQuery('#add').val({{ unavailable | json }}).addClass('disabled').prop('disabled', true);
-	}
+  } else {
+    // variant doesn't exist.
+    jQuery('#product-price').empty();
+    jQuery('#backorder').addClass('hidden');
+    jQuery('#add').val({{ unavailable | json }}).addClass('disabled').prop('disabled', true);
+  }
 
 };
 
 jQuery(function($) {
 
-	new Shopify.OptionSelectors('product-select', { product: {{ product | json }}, onVariantSelected: selectCallback, enableHistoryState: true });
+  new Shopify.OptionSelectors('product-select', { product: {{ product | json }}, onVariantSelected: selectCallback, enableHistoryState: true });
 
-	// Add label if only one product option and it isn't 'Title'.
-	{% if product.options.size == 1 and product.options.first != 'Title' %}
-		$('.selector-wrapper:eq(0)').prepend('<label>{{ product.options.first }}</label>');
-	{% endif %}
+  // Add label if only one product option and it isn't 'Title'.
+  {% if product.options.size == 1 and product.options.first != 'Title' %}
+    $('.selector-wrapper:eq(0)').prepend('<label>{{ product.options.first }}</label>');
+  {% endif %}
 
 });
 

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -1,72 +1,51 @@
-{% comment %}
-The search.liquid template is not a required template.
-That search.liquid template is included in the current theme to make it easier for you 
-to customize your /search page.
-Whether you are using your own template for the search page or not,
-the {{ content_for_header }} tag in theme.liquid will always output the following on the /search page:
-<link rel="stylesheet" href="//cdn.shopify.com/s/global/search.css" type="text/css" />
-So the /search page is always styled by a globally-hosted stylesheet called search.css.
-You may override and complement that CSS in your theme's stylesheet.
-We are using a div#searchresults below so that the styles defined in search.css get
-applied to the elements on this page; the 'searchresults' id is used in the CSS
-selectors inside search.css.
-{% endcomment %}
+{% comment %}Remove this script tag to reinstate the search page{% endcomment %}
+<script>
+	window.location.replace("{{ shop.url }}");
+</script>
 
-<div id="searchresults">
-  
-  <div class="centered">
-    <form action="/search" method="get" class="search-form" role="search">
-      <input name="q" type="search" id="search-field" placeholder="Search store..." value="{{ search.terms | escape }}" />
-      <input type="submit" id="search-submit" value="Search" />
-    </form>
-  </div>
-  
-  {% comment %}
-  search.performed is false when accessing the /search page without a 'q' parameter set
-  in the URL. A shop-owner can link to the /search page from one of his link lists.
-  It is important to show a search form on that page if search.performed is false.
-  {% endcomment %}
-  
-  {% if search.performed %}
-    
-    {% paginate search.results by 10 %}
-    
-    {% comment %}
-    Common pitfall to avoid: search.results should never be accessed before the opening 
-    paginate tag. Move the opening and closing paginate tags to the very top and bottom of your
-    search.liquid template if you need to.
-    If you fail to do the above, the pagination of search results will be broken.
-    search.results_count is fine to access in or out of the paginate block.
-    {% endcomment %}
-  
-    {% if search.results_count == 0 %}  
-    <p class="centered">Your search for "{{ search.terms }}" did not yield any results.</p>              
-    {% else %}
-    <ol>
-      {% for item in search.results %}      
-      <li class="clearfix">
-        <h3>{{ item.title | link_to: item.url }}</h3>
-        {% if item.vendor %}
-        <div class="result-image">
-          <a href="{{ item.url }}" title="{{ item.title | escape }}">
-            {{ item | img_url: 'small' | img_tag: item.featured_image.alt }}
-          </a>
-        </div>
-        {% endif %}
-        <span>{{ item.content | strip_html | truncatewords: 40 | highlight: search.terms }}</span>        
-      </li>
-      {% endfor %}
-    </ol>
-    {% endif %}    
-    
-    {% if paginate.pages > 1 %}
-    <div id="pagination">
-      {{ paginate | default_pagination }}
+{% include 'site-nav' %}
+
+<div id="main-content" class="main" role="main">
+  <section class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-12">
+        <form class="p-search-box" action="/search" method="get" role="search">
+          <input type="search" class="p-search-box__input" name="q" placeholder="Search store..." required="" value="{{ search.terms | escape }}">
+          <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+        </form>
+      </div>
+
+      <div class="col-12">
+        {% if search.performed %} 
+          {% paginate search.results by 10 %}
+        
+          {% if search.results_count == 0 %}  
+            <p>Your search for "{{ search.terms }}" did not yield any results.</p>
+          {% else %}
+            <ul class="p-list">
+              {% for item in search.results %}      
+                <li class="p-list__item">
+                  <div class="row u-sv3">
+                    <div class="col-12">
+                      <h3>{{ item.title | link_to: item.url }}</h3>
+
+                      {{ item.content | strip_html | truncatewords: 40 | highlight: search.terms }}
+                    </div>
+                  </div>      
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}    
+          
+          {% if paginate.pages > 1 %}
+            <div id="pagination">
+              {{ paginate | default_pagination }}
+            </div>
+          {% endif %}
+          
+          {% endpaginate %}    
+        {% endif %}  
+      </div>
     </div>
-    {% endif %}
-    
-    {% endpaginate %}    
-    
-  {% endif %}  
-
+  </section>
 </div>

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -3,49 +3,45 @@
 	window.location.replace("{{ shop.url }}");
 </script>
 
-{% include 'site-nav' %}
-
-<div id="main-content" class="main" role="main">
-  <section class="p-strip is-bordered">
-    <div class="row">
-      <div class="col-12">
-        <form class="p-search-box" action="/search" method="get" role="search">
-          <input type="search" class="p-search-box__input" name="q" placeholder="Search store..." required="" value="{{ search.terms | escape }}">
-          <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
-        </form>
-      </div>
-
-      <div class="col-12">
-        {% if search.performed %} 
-          {% paginate search.results by 10 %}
-        
-          {% if search.results_count == 0 %}  
-            <p>Your search for "{{ search.terms }}" did not yield any results.</p>
-          {% else %}
-            <ul class="p-list">
-              {% for item in search.results %}      
-                <li class="p-list__item">
-                  <div class="row u-sv3">
-                    <div class="col-12">
-                      <h3>{{ item.title | link_to: item.url }}</h3>
-
-                      {{ item.content | strip_html | truncatewords: 40 | highlight: search.terms }}
-                    </div>
-                  </div>      
-                </li>
-              {% endfor %}
-            </ul>
-          {% endif %}    
-          
-          {% if paginate.pages > 1 %}
-            <div id="pagination">
-              {{ paginate | default_pagination }}
-            </div>
-          {% endif %}
-          
-          {% endpaginate %}    
-        {% endif %}  
-      </div>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <form class="p-search-box" action="/search" method="get" role="search">
+        <input type="search" class="p-search-box__input" name="q" placeholder="Search store..." required="" value="{{ search.terms | escape }}">
+        <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+      </form>
     </div>
-  </section>
-</div>
+
+    <div class="col-12">
+      {% if search.performed %} 
+        {% paginate search.results by 10 %}
+      
+        {% if search.results_count == 0 %}  
+          <p>Your search for "{{ search.terms }}" did not yield any results.</p>
+        {% else %}
+          <ul class="p-list">
+            {% for item in search.results %}      
+              <li class="p-list__item">
+                <div class="row u-sv3">
+                  <div class="col-12">
+                    <h3>{{ item.title | link_to: item.url }}</h3>
+
+                    {{ item.content | strip_html | truncatewords: 40 | highlight: search.terms }}
+                  </div>
+                </div>      
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}    
+        
+        {% if paginate.pages > 1 %}
+          <div id="pagination">
+            {{ paginate | default_pagination }}
+          </div>
+        {% endif %}
+        
+        {% endpaginate %}    
+      {% endif %}  
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Done

- Fixed HTML validation errors where possible. In some cases, Shopify itself introduces validation errors with `<meta>` tags, via CMS content.
- Added Vanilla patterns to remaining pages
- Shopify provides pages at /search, /blogs/news and /products/{product.slug}. These have been Vanilla-ised should it be decided they're needed in future, but for the time being they all now redirect to the homepage.
- Refactored templates so that site nav and the `<main>` element are not repeated in each template.

## QA
- Visit https://canonical-staging.myshopify.com/hello
- See that the resulting 404 page is not broken.
- Visit:
  - https://canonical-staging.myshopify.com/search
  - https://canonical-staging.myshopify.com/blogs/news
  - https://canonical-staging.myshopify.com/products/standard-server
- See that you are redirected to the homepage
- Visit:
  - https://validator.w3.org/nu/?doc=https%3A%2F%2Fcanonical-staging.myshopify.com%2F
  - https://validator.w3.org/nu/?doc=https%3A%2F%2Fcanonical-staging.myshopify.com%2Fcart
  - https://canonical-staging.myshopify.com/collections/ubuntu-advantage-for-virtual-guests
- See that any errors or warnings relate to meta and script tags injected by Shopify

Fixes #21 